### PR TITLE
Support for enumerating key handles

### DIFF
--- a/examples/tpm-keys/tpm-keys.go
+++ b/examples/tpm-keys/tpm-keys.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2016, Kevin Walsh.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/google/go-tpm/tpm"
+)
+
+func main() {
+	var tpmname = flag.String("tpm", "/dev/tpm0", "The path to the TPM device to use")
+	var closekey = flag.Bool("close", false, "Close (unload) all existing key handles")
+	flag.Parse()
+
+	rwc, err := tpm.OpenTPM(*tpmname)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't open the TPM file %s: %s\n", *tpmname, err)
+		return
+	}
+
+	handles, err := tpm.GetKeys(rwc)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't enumerate loaded TPM keys: %s\n", err)
+		return
+	}
+
+	fmt.Printf("%d keys loaded in the TPM\n", len(handles))
+	for i, h := range handles {
+		fmt.Printf("  (%d) Key handle %d\n", i+1, h)
+		if *closekey {
+			if err = h.CloseKey(rwc); err != nil {
+				fmt.Fprintf(os.Stderr, "Couldn't close TPM key handle %d\n", h)
+			} else {
+				fmt.Printf("    Closed handle %d\n", h)
+			}
+		}
+	}
+
+	return
+}

--- a/tpm/constants.go
+++ b/tpm/constants.go
@@ -40,10 +40,16 @@ const (
 	ordLoadKey2             uint32 = 0x00000041
 	ordGetRandom            uint32 = 0x00000046
 	ordOwnerClear           uint32 = 0x0000005B
+	ordGetCapability        uint32 = 0x00000065
 	ordMakeIdentity         uint32 = 0x00000079
 	ordReadPubEK            uint32 = 0x0000007C
 	ordOwnerReadInternalPub uint32 = 0x00000081
 	ordFlushSpecific        uint32 = 0x000000BA
+)
+
+// Capability types.
+const (
+	capHandle uint32 = 0x00000014
 )
 
 // Entity types. The LSB gives the entity type, and the MSB (currently fixed to

--- a/tpm/encoding.go
+++ b/tpm/encoding.go
@@ -140,6 +140,25 @@ func packType(buf io.Writer, elts []interface{}) error {
 	return nil
 }
 
+func unpackKeyHandleList(b []byte) ([]Handle, error) {
+	// TODO(kwalsh): handle pack/unpack of TPM_KEY_HANDLE_LIST more gracefully
+	buf := bytes.NewBuffer(b)
+	var n uint16
+	if err := unpackType(buf, []interface{}{&n}); err != nil {
+		return nil, err
+	}
+	if n == 0 {
+		return nil, nil
+	}
+	h := make([]Handle, int(n))
+	for i, _ := range h {
+		if err := unpackType(buf, []interface{}{&h[i]}); err != nil {
+			return nil, err
+		}
+	}
+	return h, nil
+}
+
 // unpack performs the inverse operation from pack.
 func unpack(b []byte, elts []interface{}) error {
 	buf := bytes.NewBuffer(b)

--- a/tpm/encoding.go
+++ b/tpm/encoding.go
@@ -150,7 +150,7 @@ func unpackKeyHandleList(b []byte) ([]Handle, error) {
 	if n == 0 {
 		return nil, nil
 	}
-	h := make([]Handle, int(n))
+	h := make([]Handle, n)
 	for i, _ := range h {
 		if err := unpackType(buf, []interface{}{&h[i]}); err != nil {
 			return nil, err

--- a/tpm/encoding_test.go
+++ b/tpm/encoding_test.go
@@ -359,3 +359,38 @@ func TestEncodingUnpack(t *testing.T) {
 		t.Fatal("Unpacked struct with nested slice didn't match the original")
 	}
 }
+
+func TestUnpackKeyHandleList(t *testing.T) {
+
+	h, err := unpackKeyHandleList([]byte{0, 3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12})
+	if err != nil {
+		t.Fatal("unpackKeyHandlelist failed to unpack valid buffer:", err)
+	}
+	if len(h) != 3 {
+		t.Fatal("unpackKeyHandlelist returned wrong length array")
+	}
+	if h[0] != 0x01020304 || h[1] != 0x05060708 || h[2] != 0x090a0b0c {
+		t.Fatal("unpackKeyHandlelist returned wrong handles")
+	}
+
+	h, err = unpackKeyHandleList([]byte{0, 0})
+	if err != nil {
+		t.Fatal("unpackKeyHandlelist failed to unpack valid buffer:", err)
+	}
+	if len(h) != 0 {
+		t.Fatal("unpackKeyHandlelist returned wrong length array")
+	}
+
+	h, err = unpackKeyHandleList([]byte{0})
+	if err == nil {
+		t.Fatal("unpackKeyHandlelist incorrectly unpacked invalid buffer")
+	}
+	h, err = unpackKeyHandleList([]byte{0, 1})
+	if err == nil {
+		t.Fatal("unpackKeyHandlelist incorrectly unpacked invalid buffer")
+	}
+	h, err = unpackKeyHandleList([]byte{0, 1, 2, 3, 4})
+	if err == nil {
+		t.Fatal("unpackKeyHandlelist incorrectly unpacked invalid buffer")
+	}
+}

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -62,7 +62,7 @@ func OpenTPM(path string) (io.ReadWriteCloser, error) {
 }
 
 // GetKeys gets the list of handles for currently-loaded TPM keys.
-func GetKeys(f *os.File) ([]Handle, error) {
+func GetKeys(rw io.ReadWriter) ([]Handle, error) {
 	var b []byte
 	subCap, err := pack([]interface{}{rtKey})
 	if err != nil {
@@ -70,7 +70,7 @@ func GetKeys(f *os.File) ([]Handle, error) {
 	}
 	in := []interface{}{capHandle, subCap}
 	out := []interface{}{&b}
-	if _, err := submitTPMRequest(f, tagRQUCommand, ordGetCapability, in, out); err != nil {
+	if _, err := submitTPMRequest(rw, tagRQUCommand, ordGetCapability, in, out); err != nil {
 		return nil, err
 	}
 	return unpackKeyHandleList(b)

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -27,6 +27,21 @@ import (
 	"os"
 )
 
+// GetKeys gets the list of handles for currently-loaded TPM keys.
+func GetKeys(f *os.File) ([]Handle, error) {
+	var b []byte
+	subCap, err := pack([]interface{}{rtKey})
+	if err != nil {
+		return nil, err
+	}
+	in := []interface{}{capHandle, subCap}
+	out := []interface{}{&b}
+	if _, err := submitTPMRequest(f, tagRQUCommand, ordGetCapability, in, out); err != nil {
+		return nil, err
+	}
+	return unpackKeyHandleList(b)
+}
+
 // ReadPCR reads a PCR value from the TPM.
 func ReadPCR(f *os.File, pcr uint32) ([]byte, error) {
 	in := []interface{}{pcr}

--- a/tpm/tpm_test.go
+++ b/tpm/tpm_test.go
@@ -59,6 +59,18 @@ func openTPMOrSkip(t *testing.T) io.ReadWriteCloser {
 	return rwc
 }
 
+func TestGetKeys(t *testing.T) {
+	rwc := openTPMOrSkip(t)
+	defer rwc.Close()
+
+	handles, err := GetKeys(rwc)
+	if err != nil {
+		t.Fatal("Couldn't enumerate keys in the TPM:", err)
+	}
+
+	t.Logf("Got %d keys: % d\n", len(handles), handles)
+}
+
 func TestReadPCR(t *testing.T) {
 	rwc := openTPMOrSkip(t)
 	defer rwc.Close()


### PR DESCRIPTION
This is useful for debugging and is needed for graceful cleanup or recovery of TPM resources. Specifically, some TPMs seem to run out of key handles, causing LoadKey to fail, and the key handles persist even across reboots. Apparently, the only way to clear them short of resetting the TPM is to enumerate and explicitly unload old keys.

