### PR TITLE
Add methods for generating keys and doing sign operation.

### DIFF
--- a/examples/tpm-sign/README.md
+++ b/examples/tpm-sign/README.md
@@ -1,0 +1,32 @@
+# tpm-sign
+
+This example shows how you can generate keys inside the TPM and use them for signature/verification operations. This utility supports `sign`, `verify`, `generate`, and `extendPcr` actions. Use `./tpm-sign <action> --help` for advanced usage of each action.
+
+## Basic Usage
+The following snippet shows how you can generate a key, sign data with it, and verify the signature.
+
+```
+$ ./tpm-sign generate
+Writing keyblob to keyblob
+Writing public key to publickey
+$ echo test_data | ./tpm-sign sign
+Writing signature to sig.data
+$ echo test_data | ./tpm-sign verify
+Signature valid.
+```
+
+## Binding against PCRs
+This example shows how you can generate a key that is bound against PCR values.
+
+```
+$ ./tpm-sign extendPcr --reset --pcr 16
+$ ./tpm-sign generate --pcrs 0,16
+Writing keyblob to keyblob
+Writing public key to publickey
+$ echo test_data | ./tpm-sign sign
+Writing signature to sig.data
+$ echo test_measurement | ./tpm-sign extendPcr --pcr 16
+$ echo test_data | ./tpm-sign sign
+Could not perform sign operation: tpm: the named PCR value does not match the current PCR value
+```
+

--- a/examples/tpm-sign/common.go
+++ b/examples/tpm-sign/common.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"crypto"
+)
+
+const (
+	srkAuthEnvVar       = "TPM_SRK_AUTH"
+	usageAuthEnvVar     = "TPM_USAGE_AUTH"
+	migrationAuthEnvVar = "TPM_MIGRATION_AUTH"
+)
+
+var hashNames = map[string]crypto.Hash{
+	"MD5":       crypto.MD5,
+	"SHA1":      crypto.SHA1,
+	"SHA224":    crypto.SHA224,
+	"SHA256":    crypto.SHA256,
+	"SHA384":    crypto.SHA384,
+	"SHA512":    crypto.SHA512,
+	"MD5SHA1":   crypto.MD5SHA1,
+	"RIPEMD160": crypto.RIPEMD160,
+}

--- a/examples/tpm-sign/extend_pcr.go
+++ b/examples/tpm-sign/extend_pcr.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2018, Ian Haken. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/sha1"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/google/go-tpm/tpm"
+)
+
+func extendPcrAction() {
+	var tpmname = flag.String("tpm", "/dev/tpm0", "The path to the TPM device to use")
+	var pcrNum = flag.Int("pcr", 16, "PCR number to extend")
+	var reset = flag.Bool("reset", false, "Reset the PCR rather than extending it")
+	var dataPath = flag.String("data", "", "Path to the data that will be used to extend the PCR. If empty or omitted, the data will be read from stdin.")
+	flag.CommandLine.Parse(os.Args[2:])
+
+	rwc, err := tpm.OpenTPM(*tpmname)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't open the TPM file %s: %s\n", *tpmname, err)
+		return
+	}
+	defer rwc.Close()
+
+	if *reset {
+		if err = tpm.PcrReset(rwc, []int{*pcrNum}); err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to reset PCR: %s\n", err)
+			return
+		}
+	} else {
+		var data []byte
+		if *dataPath == "" {
+			data, err = ioutil.ReadAll(os.Stdin)
+		} else {
+			data, err = ioutil.ReadFile(*dataPath)
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to read input: %s\n", err)
+			return
+		}
+		if _, err = tpm.PcrExtend(rwc, uint32(*pcrNum), sha1.Sum(data)); err != nil {
+			fmt.Fprintf(os.Stderr, "Error extending PCR: %s\n", err)
+			return
+		}
+	}
+}

--- a/examples/tpm-sign/generate.go
+++ b/examples/tpm-sign/generate.go
@@ -31,7 +31,7 @@ func generateAction() {
 	var tpmname = flag.String("tpm", "/dev/tpm0", "The path to the TPM device to use")
 	var keyblobPath = flag.String("keyblob", "keyblob", "Output path of the generated keyblob")
 	var pubKeyPath = flag.String("publicKey", "publickey", "Output path of the generated keyblob's public key")
-	var pcrsStr = flag.String("pcrs", "", "A comma-separated list of PCR numbers againt which the generated key will be bound. If blank, it will not be bound to any PCR values.")
+	var pcrsStr = flag.String("pcrs", "", "A comma-separated list of PCR numbers against which the generated key will be bound. If blank, it will not be bound to any PCR values.")
 	flag.CommandLine.Parse(os.Args[2:])
 
 	var pcrs []int

--- a/examples/tpm-sign/generate.go
+++ b/examples/tpm-sign/generate.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2018, Ian Haken. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/sha1"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-tpm/tpm"
+)
+
+func generateAction() {
+	var tpmname = flag.String("tpm", "/dev/tpm0", "The path to the TPM device to use")
+	var keyblobPath = flag.String("keyblob", "keyblob", "Output path of the generated keyblob")
+	var pubKeyPath = flag.String("publicKey", "publickey", "Output path of the generated keyblob's public key")
+	var pcrsStr = flag.String("pcrs", "", "A comma-separated list of PCR numbers againt which the generated key will be bound. If blank, it will not be bound to any PCR values.")
+	flag.CommandLine.Parse(os.Args[2:])
+
+	var pcrs []int
+	if *pcrsStr != "" {
+		for _, pcr := range strings.Split(*pcrsStr, ",") {
+			pcrNum, err := strconv.Atoi(pcr)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Bad value in pcrs argument: %s\n", pcr)
+				return
+			}
+			pcrs = append(pcrs, pcrNum)
+		}
+	}
+
+	rwc, err := tpm.OpenTPM(*tpmname)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't open the TPM file %s: %s\n", *tpmname, err)
+		return
+	}
+	defer rwc.Close()
+
+	// Compute the auth values as needed.
+	var srkAuth [20]byte
+	srkInput := os.Getenv(srkAuthEnvVar)
+	if srkInput != "" {
+		sa := sha1.Sum([]byte(srkInput))
+		copy(srkAuth[:], sa[:])
+	}
+
+	var usageAuth [20]byte
+	usageInput := os.Getenv(usageAuthEnvVar)
+	if usageInput != "" {
+		ua := sha1.Sum([]byte(usageInput))
+		copy(usageAuth[:], ua[:])
+	}
+
+	var migrationAuth [20]byte
+	migrationInput := os.Getenv(migrationAuthEnvVar)
+	if migrationInput != "" {
+		ma := sha1.Sum([]byte(migrationInput))
+		copy(migrationAuth[:], ma[:])
+	}
+
+	keyblob, err := tpm.CreateWrapKey(rwc, srkAuth[:], usageAuth, migrationAuth, pcrs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't make a new signing key: %s\n", err)
+		return
+	}
+	fmt.Printf("Writing keyblob to %s\n", *keyblobPath)
+	if err = ioutil.WriteFile(*keyblobPath, keyblob, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing keyblob file: %s\n", err)
+		return
+	}
+
+	pubKey, err := tpm.UnmarshalRSAPublicKey(keyblob)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not get public key: %s\n", err)
+		return
+	}
+
+	pubKeyBytes, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not marshal public key: %s\n", err)
+		return
+	}
+	fmt.Printf("Writing public key to %s\n", *pubKeyPath)
+	if err = ioutil.WriteFile(*pubKeyPath, pubKeyBytes, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing public key file: %s\n", err)
+		return
+	}
+}

--- a/examples/tpm-sign/sign.go
+++ b/examples/tpm-sign/sign.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2018, Ian Haken. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/sha1"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/google/go-tpm/tpm"
+)
+
+func signAction() {
+	var tpmname = flag.String("tpm", "/dev/tpm0", "The path to the TPM device to use")
+	var keyblobPath = flag.String("keyblob", "keyblob", "Input path of the keyblob to use")
+	var signaturePath = flag.String("signature", "sig.data", "Output path of the signature")
+	var hashAlgArg = flag.String("hash", "SHA256", "Hash algorithm to use when generating the signature")
+	var dataPath = flag.String("data", "", "Path to the data that will be signed. If empty or omitted, the data will be read from stdin.")
+	flag.CommandLine.Parse(os.Args[2:])
+
+	hashAlg, ok := hashNames[*hashAlgArg]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Invalid hash algorithm: %s\n", *hashAlgArg)
+		return
+	}
+
+	rwc, err := tpm.OpenTPM(*tpmname)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't open the TPM file %s: %s\n", *tpmname, err)
+		return
+	}
+	defer rwc.Close()
+
+	// Compute the auth values as needed.
+	var srkAuth [20]byte
+	srkInput := os.Getenv(srkAuthEnvVar)
+	if srkInput != "" {
+		sa := sha1.Sum([]byte(srkInput))
+		copy(srkAuth[:], sa[:])
+	}
+
+	var usageAuth [20]byte
+	usageInput := os.Getenv(usageAuthEnvVar)
+	if usageInput != "" {
+		ua := sha1.Sum([]byte(usageInput))
+		copy(usageAuth[:], ua[:])
+	}
+
+	var migrationAuth [20]byte
+	migrationInput := os.Getenv(migrationAuthEnvVar)
+	if migrationInput != "" {
+		ma := sha1.Sum([]byte(migrationInput))
+		copy(migrationAuth[:], ma[:])
+	}
+
+	keyblob, err := ioutil.ReadFile(*keyblobPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading keyblob file: %s\n", err)
+		return
+	}
+	keyHandle, err := tpm.LoadKey2(rwc, keyblob, srkAuth[:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not load keyblob: %s\n", err)
+		return
+	}
+	defer keyHandle.CloseKey(rwc)
+
+	var data []byte
+	if *dataPath == "" {
+		data, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		data, err = ioutil.ReadFile(*dataPath)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading input data: %s\n", err)
+		return
+	}
+
+	hash := hashAlg.New()
+	if _, err = hash.Write(data); err != nil {
+		fmt.Fprintf(os.Stderr, "Error building hash of data: %s\n", err)
+		return
+	}
+	hashed := hash.Sum(nil)
+	signature, err := tpm.Sign(rwc, usageAuth[:], keyHandle, hashAlg, hashed[:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not perform sign operation: %s\n", err)
+		return
+	}
+	fmt.Printf("Writing signature to %s\n", *signaturePath)
+	if err = ioutil.WriteFile(*signaturePath, signature, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to write signature to file: %s\n", err)
+		return
+	}
+}

--- a/examples/tpm-sign/tpm-sign.go
+++ b/examples/tpm-sign/tpm-sign.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2014, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/sha1"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/google/go-tpm/tpm"
+)
+
+var (
+	ownerAuthEnvVar = "TPM_OWNER_AUTH"
+	srkAuthEnvVar   = "TPM_SRK_AUTH"
+)
+
+func main() {
+	var tpmname = flag.String("tpm", "/dev/tpm0", "The path to the TPM device to use")
+	flag.Parse()
+
+	rwc, err := tpm.OpenTPM(*tpmname)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't open the TPM file %s: %s\n", *tpmname, err)
+		return
+	}
+
+	// Compute the auth values as needed.
+	var ownerAuth [20]byte
+	ownerInput := os.Getenv(ownerAuthEnvVar)
+	if ownerInput != "" {
+		oa := sha1.Sum([]byte(ownerInput))
+		copy(ownerAuth[:], oa[:])
+	}
+
+	var srkAuth [20]byte
+	srkInput := os.Getenv(srkAuthEnvVar)
+	if srkInput != "" {
+		sa := sha1.Sum([]byte(srkInput))
+		copy(srkAuth[:], sa[:])
+	}
+
+	pubek, err := tpm.ReadPubEK(rwc)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't read the endorsement key: %s\n", err)
+		return
+	}
+
+	if err := tpm.TakeOwnership(rwc, ownerAuth, srkAuth, pubek); err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't take ownership of the TPM: %s\n", err)
+		return
+	}
+
+	return
+}

--- a/examples/tpm-sign/tpm-sign.go
+++ b/examples/tpm-sign/tpm-sign.go
@@ -27,15 +27,16 @@ func main() {
 	if len(os.Args) < 2 {
 		showUsage()
 	} else {
-		if os.Args[1] == "sign" {
+		switch os.Args[1] {
+		case "sign":
 			signAction()
-		} else if os.Args[1] == "verify" {
+		case "verify":
 			verifyAction()
-		} else if os.Args[1] == "generate" {
+		case "generate":
 			generateAction()
-		} else if os.Args[1] == "extendPcr" {
+		case "extendPcr":
 			extendPcrAction()
-		} else {
+		default:
 			showUsage()
 		}
 	}

--- a/examples/tpm-sign/tpm-sign.go
+++ b/examples/tpm-sign/tpm-sign.go
@@ -15,126 +15,28 @@
 package main
 
 import (
-	"crypto"
-	"crypto/rsa"
-	"crypto/sha1"
-	"crypto/sha256"
-	"crypto/x509"
-	"encoding/base64"
-	"flag"
 	"fmt"
 	"os"
-
-	"github.com/google/go-tpm/tpm"
 )
 
-var (
-	ownerAuthEnvVar     = "TPM_OWNER_AUTH"
-	srkAuthEnvVar       = "TPM_SRK_AUTH"
-	usageAuthEnvVar     = "TPM_USAGE_AUTH"
-	migrationAuthEnvVar = "TPM_MIGRATION_AUTH"
-)
+func showUsage() {
+	fmt.Println("Usage: ./tpm-sign <sign|verify|generate|extendPcr> [...]")
+}
 
 func main() {
-	var tpmname = flag.String("tpm", "/dev/tpm0", "The path to the TPM device to use")
-	flag.Parse()
-
-	rwc, err := tpm.OpenTPM(*tpmname)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Couldn't open the TPM file %s: %s\n", *tpmname, err)
-		return
+	if len(os.Args) < 2 {
+		showUsage()
+	} else {
+		if os.Args[1] == "sign" {
+			signAction()
+		} else if os.Args[1] == "verify" {
+			verifyAction()
+		} else if os.Args[1] == "generate" {
+			generateAction()
+		} else if os.Args[1] == "extendPcr" {
+			extendPcrAction()
+		} else {
+			showUsage()
+		}
 	}
-	defer rwc.Close()
-
-	// Compute the auth values as needed.
-	var ownerAuth [20]byte
-	ownerInput := os.Getenv(ownerAuthEnvVar)
-	if ownerInput != "" {
-		oa := sha1.Sum([]byte(ownerInput))
-		copy(ownerAuth[:], oa[:])
-	}
-
-	var srkAuth [20]byte
-	srkInput := os.Getenv(srkAuthEnvVar)
-	if srkInput != "" {
-		sa := sha1.Sum([]byte(srkInput))
-		copy(srkAuth[:], sa[:])
-	}
-
-	var usageAuth [20]byte
-	usageInput := os.Getenv(usageAuthEnvVar)
-	if usageInput != "" {
-		ua := sha1.Sum([]byte(usageInput))
-		copy(usageAuth[:], ua[:])
-	}
-
-	var migrationAuth [20]byte
-	migrationInput := os.Getenv(migrationAuthEnvVar)
-	if migrationInput != "" {
-		ma := sha1.Sum([]byte(migrationInput))
-		copy(migrationAuth[:], ma[:])
-	}
-
-	keyblob, err := tpm.CreateWrapKey(rwc, srkAuth[:], usageAuth, migrationAuth, []int{0, 1, 2, 3, 4, 16})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Couldn't make a new signing key: %s\n", err)
-		return
-	}
-	fmt.Printf("Keyblob: %s\n", base64.StdEncoding.EncodeToString(keyblob))
-
-	pubKey, err := tpm.UnmarshalRSAPublicKey(keyblob)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not get public key: %s\n", err)
-		return
-	}
-
-	pubKeyBytes, err := x509.MarshalPKIXPublicKey(pubKey)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not marshal public key: %s\n", err)
-		return
-	}
-	fmt.Printf("Public Key: %s\n", base64.StdEncoding.EncodeToString(pubKeyBytes))
-
-	keyHandle, err := tpm.LoadKey2(rwc, keyblob, srkAuth[:])
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not load keyblob: %s\n", err)
-		return
-	}
-	defer keyHandle.CloseKey(rwc)
-
-	hashed := sha256.Sum256([]byte("Hello, World!"))
-	signature, err := tpm.Sign(rwc, usageAuth[:], keyHandle, crypto.SHA256, hashed[:])
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not perform sign operation: %s\n", err)
-		return
-	}
-
-	fmt.Printf("Signature: %s\n", base64.StdEncoding.EncodeToString(signature))
-
-	if err = rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hashed[:], signature); err != nil {
-		fmt.Fprintf(os.Stderr, "Error from verification: %s\n", err)
-		return
-	}
-	fmt.Printf("Signature valid.\n")
-
-	// Extend PCR 16.
-	if _, err = tpm.PcrExtend(rwc, 16, sha1.Sum([]byte("xyz"))); err != nil {
-		fmt.Fprintf(os.Stderr, "Error extending PCR: %s\n", err)
-		return
-	}
-	if _, err = tpm.Sign(rwc, usageAuth[:], keyHandle, crypto.SHA256, hashed[:]); err == nil {
-		fmt.Fprintf(os.Stderr, "Should have failed to sign with extended PCR.")
-		return
-	}
-	if err = tpm.PcrReset(rwc, []int{16}); err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to reset PCR: %s\n", err)
-		return
-	}
-
-	if _, err = tpm.Sign(rwc, usageAuth[:], keyHandle, crypto.SHA256, hashed[:]); err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to sign with PCR reset: %s\n", err)
-		return
-	}
-
-	return
 }

--- a/examples/tpm-sign/verify.go
+++ b/examples/tpm-sign/verify.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2018, Ian Haken. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+func verifyAction() {
+	var pubKeyPath = flag.String("publicKey", "publickey", "Input path of public key file")
+	var hashAlgArg = flag.String("hash", "SHA256", "Hash algorithm to use when verifying the signature")
+	var signaturePath = flag.String("signature", "sig.data", "Input path of previously generated signature")
+	var dataPath = flag.String("data", "", "Path to the data that was signed. If empty or omitted, the data will be read from stdin.")
+	flag.CommandLine.Parse(os.Args[2:])
+
+	hashAlg, ok := hashNames[*hashAlgArg]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Invalid hash algorithm: %s\n", *hashAlgArg)
+		return
+	}
+
+	var err error
+	var data []byte
+	if *dataPath == "" {
+		data, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		data, err = ioutil.ReadFile(*dataPath)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading input data: %s\n", err)
+		return
+	}
+
+	signature, err := ioutil.ReadFile(*signaturePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading signature file: %s\n", err)
+		return
+	}
+
+	pubKeyBytes, err := ioutil.ReadFile(*pubKeyPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading public key file: %s\n", err)
+		return
+	}
+	pubKey, err := x509.ParsePKIXPublicKey(pubKeyBytes)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing public key: %s\n", err)
+		return
+	}
+	rsaPubKey, ok := pubKey.(*rsa.PublicKey)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Expected public key to be an RSA key, but was %T\n", pubKey)
+		return
+	}
+
+	hash := hashAlg.New()
+	if _, err = hash.Write(data); err != nil {
+		fmt.Fprintf(os.Stderr, "Error building hash of data: %s\n", err)
+		return
+	}
+	hashed := hash.Sum(nil)
+	if err = rsa.VerifyPKCS1v15(rsaPubKey, hashAlg, hashed[:], signature); err != nil {
+		fmt.Fprintf(os.Stderr, "Error from verification: %s\n", err)
+		return
+	}
+	fmt.Printf("Signature valid.\n")
+}

--- a/tpm/commands.go
+++ b/tpm/commands.go
@@ -324,3 +324,38 @@ func takeOwnership(rw io.ReadWriter, encOwnerAuth []byte, encSRKAuth []byte, srk
 
 	return &k, &ra, ret, nil
 }
+
+// Creates a wrapped key under the SRK.
+func createWrapKey(rw io.ReadWriter, encUsageAuth digest, encMigrationAuth digest, keyInfo *key, ca *commandAuth) (*key, *responseAuth, uint32, error) {
+	in := []interface{}{khSRK, encUsageAuth, encMigrationAuth, keyInfo, ca}
+	var k key
+	var ra responseAuth
+	out := []interface{}{&k, &ra}
+	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordCreateWrapKey, in, out)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	return &k, &ra, ret, nil
+}
+
+func sign(rw io.ReadWriter, keyHandle Handle, data []byte, ca *commandAuth) ([]byte, *responseAuth, uint32, error) {
+	in := []interface{}{keyHandle, data, ca}
+	var signature []byte
+	var ra responseAuth
+	out := []interface{}{&signature, &ra}
+	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordSign, in, out)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	return signature, &ra, ret, nil
+}
+
+func pcrReset(rw io.ReadWriter, pcrs *pcrSelection) error {
+	_, err := submitTPMRequest(rw, tagRQUCommand, ordPcrReset, []interface{}{pcrs}, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/tpm/constants.go
+++ b/tpm/constants.go
@@ -35,7 +35,9 @@ const (
 	ordQuote                uint32 = 0x00000016
 	ordSeal                 uint32 = 0x00000017
 	ordUnseal               uint32 = 0x00000018
+	ordCreateWrapKey        uint32 = 0x0000001F
 	ordGetPubKey            uint32 = 0x00000021
+	ordSign                 uint32 = 0x0000003C
 	ordQuote2               uint32 = 0x0000003E
 	ordResetLockValue       uint32 = 0x00000040
 	ordLoadKey2             uint32 = 0x00000041
@@ -46,6 +48,7 @@ const (
 	ordReadPubEK            uint32 = 0x0000007C
 	ordOwnerReadInternalPub uint32 = 0x00000081
 	ordFlushSpecific        uint32 = 0x000000BA
+	ordPcrReset             uint32 = 0x000000C8
 )
 
 // Capability types.

--- a/tpm/pcrs.go
+++ b/tpm/pcrs.go
@@ -129,3 +129,28 @@ func newPCRInfoLong(rw io.ReadWriter, loc byte, pcrNums []int) (*pcrInfoLong, er
 
 	return createPCRInfoLong(loc, mask, pcrVals)
 }
+
+func newPCRInfo(rw io.ReadWriter, pcrNums []int) (*pcrInfo, error) {
+	var mask pcrMask
+	for _, pcr := range pcrNums {
+		if err := mask.setPCR(pcr); err != nil {
+			return nil, err
+		}
+	}
+
+	pcrVals, err := FetchPCRValues(rw, pcrNums)
+	if err != nil {
+		return nil, err
+	}
+	d, err := createPCRComposite(mask, pcrVals)
+	if err != nil {
+		return nil, err
+	}
+	pcri := &pcrInfo{
+		PcrSelection: pcrSelection{3, mask},
+	}
+	copy(pcri.DigestAtRelease[:], d)
+	copy(pcri.DigestAtCreation[:], d)
+
+	return pcri, nil
+}

--- a/tpm/structures.go
+++ b/tpm/structures.go
@@ -59,6 +59,12 @@ type pcrInfoShort struct {
 	DigestAtRelease digest
 }
 
+type pcrInfo struct {
+	PcrSelection     pcrSelection
+	DigestAtRelease  digest
+	DigestAtCreation digest
+}
+
 // A capVersionInfo contains information about the TPM itself. Note that this
 // is deserialized specially, since it has a variable-length byte array but no
 // length. It is preceeded with a length in the response to the Quote2 command.

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -873,11 +873,14 @@ func TakeOwnership(rw io.ReadWriter, newOwnerAuth digest, newSRKAuth digest, pub
 	return ra.verify(ca.NonceOdd, newOwnerAuth[:], raIn)
 }
 
-// CreateWrapKey creates a new RSA key for signatures inside the TPM. It is wrapped by the SRK (which is to say,
-// the SRK is the parent key). The key can be bound to the specified PCR numbers so that it can only be used for
-// signing if the PCR values of those registers match. The pcrs parameter can be nil in which case the key is
-// not bound to any PCRs. The usageAuth parameter defines the auth key for using this new key. The migrationAuth
-// parameter would be used for authorizing migration of the key (although this code currently disables migration).
+// CreateWrapKey creates a new RSA key for signatures inside the TPM. It is
+// wrapped by the SRK (which is to say, the SRK is the parent key). The key can
+// be bound to the specified PCR numbers so that it can only be used for
+// signing if the PCR values of those registers match. The pcrs parameter can
+// be nil in which case the key is not bound to any PCRs. The usageAuth
+// parameter defines the auth key for using this new key. The migrationAuth
+// parameter would be used for authorizing migration of the key (although this
+// code currently disables migration).
 func CreateWrapKey(rw io.ReadWriter, srkAuth []byte, usageAuth digest, migrationAuth digest, pcrs []int) ([]byte, error) {
 	// Run OSAP for the SRK, reading a random OddOSAP for our initial
 	// command and getting back a secret and a handle.


### PR DESCRIPTION
Add and example for generating a keyblob, getting its public key, generating a signature, and verifying it. Add method for reseting PCRs so that the tpm-sign example can demonstrate binding to PCR values.