### PR TITLE
Decode attest data

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -133,7 +133,7 @@ const (
 	tagNoSessions    tpmutil.Tag = 0x8001
 	tagSessions      tpmutil.Tag = 0x8002
 	tagAttestCertify tpmutil.Tag = 0x8017
-	tagHashcheck     tpmutil.Tag = 0x8024
+	tagHashCheck     tpmutil.Tag = 0x8024
 )
 
 // StartupType instructs the TPM on how to handle its state during Shutdown or
@@ -231,7 +231,7 @@ func digestSize(alg Algorithm) int {
 
 const defaultRSAExponent = 1<<16 + 1
 
-var toGoHashes = map[Algorithm]func() hash.Hash{
+var hashConstructors = map[Algorithm]func() hash.Hash{
 	AlgSHA1:   sha1.New,
 	AlgSHA256: sha256.New,
 	AlgSHA384: sha512.New384,

--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -128,10 +128,11 @@ const (
 )
 
 const (
-	tagNull       tpmutil.Tag = 0x8000
-	tagNoSessions tpmutil.Tag = 0x8001
-	tagSessions   tpmutil.Tag = 0x8002
-	tagHashcheck  tpmutil.Tag = 0x8024
+	tagNull          tpmutil.Tag = 0x8000
+	tagNoSessions    tpmutil.Tag = 0x8001
+	tagSessions      tpmutil.Tag = 0x8002
+	tagAttestCertify tpmutil.Tag = 0x8017
+	tagHashcheck     tpmutil.Tag = 0x8024
 )
 
 // StartupType instructs the TPM on how to handle its state during Shutdown or
@@ -228,3 +229,11 @@ func digestSize(alg Algorithm) int {
 }
 
 const defaultRSAExponent = 1<<16 + 1
+
+var hashSizes = map[Algorithm]int{
+	AlgNull:   0,
+	AlgSHA1:   20,
+	AlgSHA256: 32,
+	AlgSHA384: 48,
+	AlgSHA512: 64,
+}

--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
+	"hash"
 
 	"github.com/google/go-tpm/tpmutil"
 )
@@ -230,10 +231,9 @@ func digestSize(alg Algorithm) int {
 
 const defaultRSAExponent = 1<<16 + 1
 
-var hashSizes = map[Algorithm]int{
-	AlgNull:   0,
-	AlgSHA1:   20,
-	AlgSHA256: 32,
-	AlgSHA384: 48,
-	AlgSHA512: 64,
+var toGoHashes = map[Algorithm]func() hash.Hash{
+	AlgSHA1:   sha1.New,
+	AlgSHA256: sha256.New,
+	AlgSHA384: sha512.New384,
+	AlgSHA512: sha512.New,
 }

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -985,7 +985,7 @@ func encodeSign(key tpmutil.Handle, password string, digest []byte) ([]byte, err
 	if err != nil {
 		return nil, err
 	}
-	params, err := tpmutil.Pack(digest, AlgNull, tagHashcheck, HandleNull, []byte(nil))
+	params, err := tpmutil.Pack(digest, AlgNull, tagHashCheck, HandleNull, []byte(nil))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
During remote attestation, remote process needs to check that the
attested key pair matches attestation data. Attestation data is what's
actually signed during TPM2_Certify.

Also added MatchesPublic helper to Name.

Remote process will have to:
- verify signature of attestDataRaw using attestation certificate
- attestData = DecodeAttestationData(attestDataRaw)
- attestData.AttestedCertifyInfo.Name.MatchesPublic(Public{publicKey})
  where publicKey is the attested key

Remote process doesn't need a TPM device to do the above.