### PR TITLE
Update link to TCG documentation

### DIFF
--- a/examples/tpm2-ekcert/main.go
+++ b/examples/tpm2-ekcert/main.go
@@ -15,7 +15,7 @@ import (
 var (
 	tpmPath = flag.String("tpm-path", "/dev/tpm0", "Path to the TPM device (character device or a Unix socket)")
 	// Default value is defined in section 7.8
-	// https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-v2.0-Provisioning-Guidance-Published-v1r1.pdf
+	// https://trustedcomputinggroup.org/resource/tcg-tpm-v2-0-provisioning-guidance/
 	certIndex = flag.Uint("cert-index", 0x01C00002, "NVRAM index of the certificate file")
 	outPath   = flag.String("output", "", "File path for output; leave blank to write to stdout")
 )


### PR DESCRIPTION
This links to the landing page for the "Provisioning Guidance" document rather than the version-specific PDF. This way, if the TCG makes updates to the document, the comment will point people to the most recent version.