### PR TITLE
Cleanup maxTPMResponse variable

### DIFF
--- a/tpm/constants.go
+++ b/tpm/constants.go
@@ -158,12 +158,6 @@ const (
 	authPrivUseOnly byte = 0x03
 )
 
-// maxTPMResponse is the largest possible response from the TPM. We need to know
-// this because we don't always know the length of the TPM response, and
-// /dev/tpm insists on giving it all back in a single value rather than
-// returning a header and a body in separate responses.
-const maxTPMResponse = 4096
-
 // fixedQuote is the fixed constant string used in quoteInfo.
 var fixedQuote = [4]byte{byte('Q'), byte('U'), byte('O'), byte('T')}
 

--- a/tpmutil/run.go
+++ b/tpmutil/run.go
@@ -58,6 +58,10 @@ func OpenTPM(path string) (io.ReadWriteCloser, error) {
 	return rwc, nil
 }
 
+// maxTPMResponse is the largest possible response from the TPM. We need to know
+// this because we don't always know the length of the TPM response, and
+// /dev/tpm insists on giving it all back in a single value rather than
+// returning a header and a body in separate responses.
 const maxTPMResponse = 4096
 
 // RunCommand executes cmd with given tag and arguments. Returns TPM response


### PR DESCRIPTION
The maxTPMResponse variable is only used by the tpmutil package, so its comments should be there as well.

I looked through the TCG specification and was unable to find any firm statement that the maxiumum response was 4096. Does anyone have the citation to the TPM1 or TPM2 spec?