### PR TITLE
Remove extraneous null handle argument.

### DIFF
--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -251,7 +251,7 @@ func encodePasswordAuthArea(passwords ...string) ([]byte, error) {
 }
 
 func encodePCREvent(pcr tpmutil.Handle, eventData []byte) ([]byte, error) {
-	ha, err := tpmutil.Pack(pcr, HandleNull)
+	ha, err := tpmutil.Pack(pcr)
 	if err != nil {
 		return nil, err
 	}

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -558,3 +558,14 @@ func TestSign(t *testing.T) {
 		})
 	})
 }
+
+func TestPCREvent(t *testing.T) {
+	rw := openTPM(t)
+	defer rw.Close()
+	debugPCR := uint32(16)
+	arbitraryBytes := []byte{1}
+	err := PCREvent(rw, tpmutil.Handle(debugPCR), arbitraryBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -564,8 +564,7 @@ func TestPCREvent(t *testing.T) {
 	defer rw.Close()
 	debugPCR := uint32(16)
 	arbitraryBytes := []byte{1}
-	err := PCREvent(rw, tpmutil.Handle(debugPCR), arbitraryBytes)
-	if err != nil {
+	if err := PCREvent(rw, tpmutil.Handle(debugPCR), arbitraryBytes); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This extraneous null handle argument is not present in the TPM2_PCR_Event
command spec and causes the command to return a 0x95 response code
(TPM_RC_SIZE).