### PR TITLE
Allow nil slices to be used with the TBS library

### DIFF
--- a/tpmutil/tbs/tbs_windows.go
+++ b/tpmutil/tbs/tbs_windows.go
@@ -173,9 +173,10 @@ func (context Context) Close() error {
 	return getError(result)
 }
 
-// SubmitCommand sends commandBuffer to the TPM, returning the number of bytes written
-// to responseBuffer. If responseBuffer is too small (ErrInsufficientBuffer), the required
-// size is returned.
+// SubmitCommand sends commandBuffer to the TPM, returning the number of bytes
+// written to responseBuffer. ErrInsufficientBuffer is returned if the
+// responseBuffer is too short. ErrInvalidOutputPointer is returned if the
+// responseBuffer is nil. On failure, the returned length is unspecified.
 // https://docs.microsoft.com/en-us/windows/desktop/api/Tbs/nf-tbs-tbsip_submit_command
 func (context Context) SubmitCommand(
 	priority CommandPriority,
@@ -206,8 +207,9 @@ func (context Context) SubmitCommand(
 }
 
 // GetTCGLog gets the system event log, returning the number of bytes written
-// to responseBuffer. If logBuffer is nil, the required size and
-// ErrInsufficientBuffer are returned.
+// to logBuffer. If logBuffer is nil, the size of the TCG log is returned.
+// ErrInsufficientBuffer is returned if the logBuffer is too short. On failure,
+// the returned length is unspecified.
 // https://docs.microsoft.com/en-us/windows/desktop/api/Tbs/nf-tbs-tbsi_get_tcg_log
 func (context Context) GetTCGLog(logBuffer []byte) (uint32, error) {
 	logBufferLen := uint32(len(logBuffer))

--- a/tpmutil/tbs/tbs_windows.go
+++ b/tpmutil/tbs/tbs_windows.go
@@ -136,6 +136,14 @@ var (
 	tbsGetTCGLog     = tbsDLL.NewProc("Tbsi_Get_TCG_Log")
 )
 
+// Returns the address of the beginning of a slice or 0 for a nil slice.
+func sliceAddress(s []byte) uintptr {
+	if len(s) == 0 {
+		return 0
+	}
+	return uintptr(unsafe.Pointer(&(s[0])))
+}
+
 // CreateContext creates a new TPM context:
 // https://docs.microsoft.com/en-us/windows/desktop/api/Tbs/nf-tbs-tbsi_context_create
 func CreateContext(version Version, flag Flag) (Context, error) {
@@ -189,17 +197,17 @@ func (context Context) SubmitCommand(
 		uintptr(context),
 		uintptr(commandLocalityZero),
 		uintptr(priority),
-		uintptr(unsafe.Pointer(&(commandBuffer[0]))),
+		sliceAddress(commandBuffer),
 		uintptr(len(commandBuffer)),
-		uintptr(unsafe.Pointer(&(responseBuffer[0]))),
+		sliceAddress(responseBuffer),
 		uintptr(unsafe.Pointer(&responseBufferLen)),
 	)
 	return responseBufferLen, getError(result)
 }
 
 // GetTCGLog gets the system event log, returning the number of bytes written
-// to responseBuffer. If responseBuffer is too small (ErrInsufficientBuffer), the required
-// size is returned.
+// to responseBuffer. If logBuffer is nil, the required size and
+// ErrInsufficientBuffer are returned.
 // https://docs.microsoft.com/en-us/windows/desktop/api/Tbs/nf-tbs-tbsi_get_tcg_log
 func (context Context) GetTCGLog(logBuffer []byte) (uint32, error) {
 	logBufferLen := uint32(len(logBuffer))
@@ -211,7 +219,7 @@ func (context Context) GetTCGLog(logBuffer []byte) (uint32, error) {
 	// );
 	result, _, _ := tbsGetTCGLog.Call(
 		uintptr(context),
-		uintptr(unsafe.Pointer(&(logBuffer[0]))),
+		sliceAddress(logBuffer),
 		uintptr(unsafe.Pointer(&logBufferLen)),
 	)
 	return logBufferLen, getError(result)

--- a/tpmutil/tbs/tbs_windows_test.go
+++ b/tpmutil/tbs/tbs_windows_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 )
 
-
 var (
-	// Encodes a call to Getrandom with a length of 0
-	encodedCommand = []byte{128, 1, 0, 0, 0, 12, 0, 0, 1, 123, 0, 0}
+	// Encodes a call to Getrandom() with a buffer of length zero, meaning
+	// this command effictivly does nothing.
+	encodedTestCommand = []byte{128, 1, 0, 0, 0, 12, 0, 0, 1, 123, 0, 0}
 	// Expected response buffer for the above command
-	expectedResponse = []byte{128, 1, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0}
+	expectedTestResponse = []byte{128, 1, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0}
 )
 
 func getContext(t *testing.T) Context {
@@ -37,7 +37,7 @@ func TestGetLogLargeBuffer(t *testing.T) {
 			return
 		}
 		if err != ErrInsufficientBuffer {
-			t.Fatalf("GetTCGLog failed: err = %v", err)
+			t.Fatalf("GetTCGLog failed: %v", err)
 		}
 		log = make([]byte, 2*len(log))
 	}
@@ -50,7 +50,7 @@ func TestGetLogWithNilSlice(t *testing.T) {
 
 	logLen, err := ctx.GetTCGLog(nil)
 	if err != nil {
-		t.Fatalf("First GetTCGLog failed: err = %v", err)
+		t.Fatalf("First GetTCGLog failed: %v", err)
 	}
 	if logLen == 0 {
 		t.Fatal("Expected positive TCGLog length")
@@ -58,11 +58,11 @@ func TestGetLogWithNilSlice(t *testing.T) {
 
 	log := make([]byte, logLen)
 	if _, err := ctx.GetTCGLog(log); err != nil {
-		t.Fatalf("Second GetTCGLog failed: err = %v", err)
+		t.Fatalf("Second GetTCGLog failed: %v", err)
 	}
 }
 
-// Make sure SubmitCommand can handle a nil command buffer.
+// SubmitCommand can handle a nil command buffer.
 func TestSubmitCommandNilCommand(t *testing.T) {
 	ctx := getContext(t)
 	defer ctx.Close()
@@ -70,45 +70,45 @@ func TestSubmitCommandNilCommand(t *testing.T) {
 	response := make([]byte, os.Getpagesize())
 	_, err := ctx.SubmitCommand(NormalPriority, nil, response)
 	if err != ErrBadParameter {
-		t.Fatalf("Expected ErrBadParameter from Submit Command: got %v", err)
+		t.Fatalf("SubmitCommand failed with %v: expected ErrBadParameter", err)
 	}
 }
 
-// Make sure SubmitCommand can handle a nil response buffer.
+// SubmitCommand can handle a nil response buffer.
 func TestSubmitCommandNilResponse(t *testing.T) {
 	ctx := getContext(t)
 	defer ctx.Close()
 
-	_, err := ctx.SubmitCommand(NormalPriority, encodedCommand, nil)
+	_, err := ctx.SubmitCommand(NormalPriority, encodedTestCommand, nil)
 	if err != ErrInvalidOutputPointer {
-		t.Fatalf("Expected ErrInvalidOutputPointer from Submit Command: got %v", err)
+		t.Fatalf("SubmitCommand failed with %v: expected ErrInvalidOutputPointer", err)
 	}
 }
 
-// Make sure SubmitCommand can handle a short response buffer.
+// SubmitCommand can handle a response buffer that is shorter than necessary.
 func TestSubmitCommandShortResponse(t *testing.T) {
 	ctx := getContext(t)
 	defer ctx.Close()
 
 	response := make([]byte, 1)
-	_, err := ctx.SubmitCommand(NormalPriority, encodedCommand, response)
+	_, err := ctx.SubmitCommand(NormalPriority, encodedTestCommand, response)
 	if err != ErrInsufficientBuffer {
-		t.Fatalf("Expected ErrInsufficientBuffer from Submit Command: got %v", err)
+		t.Fatalf("SubmitCommand failed with %v: expected ErrInsufficientBuffer", err)
 	}
 }
 
-// Make sure SubmitCommand can handle a long response buffer.
+// SubmitCommand can handle a response buffer that is longer than necessary.
 func TestSubmitCommandLongResponse(t *testing.T) {
 	ctx := getContext(t)
 	defer ctx.Close()
 
 	response := make([]byte, 100)
-	responseLen, err := ctx.SubmitCommand(NormalPriority, encodedCommand, response)
+	responseLen, err := ctx.SubmitCommand(NormalPriority, encodedTestCommand, response)
 	if err != nil {
-		t.Fatalf("SubmitCommand failed: err = %v", err)
+		t.Fatalf("SubmitCommand failed: %v", err)
 	}
 	response = response[:responseLen]
-	if !bytes.Equal(response, expectedResponse) {
-		t.Fatalf("Got response of %v, expected %v", response, expectedResponse)
+	if !bytes.Equal(response, expectedTestResponse) {
+		t.Fatalf("Got response of %v, expected %v", response, expectedTestResponse)
 	}
 }

--- a/tpmutil/tbs/tbs_windows_test.go
+++ b/tpmutil/tbs/tbs_windows_test.go
@@ -1,0 +1,54 @@
+package tbs
+
+import (
+	"os"
+	"testing"
+)
+
+func getContext(t *testing.T) Context {
+	ctx, err := CreateContext(TPMVersion20, IncludeTPM12|IncludeTPM20)
+	if err != nil {
+		t.Fatalf("Could not get tbs.Context: %v", err)
+	}
+	return ctx
+}
+
+// Get the log by passing in progressivly larger buffers
+func TestGetLogLargeBuffer(t *testing.T) {
+	ctx := getContext(t)
+	defer ctx.Close()
+
+	log := make([]byte, os.Getpagesize())
+	for {
+		logLen, err := ctx.GetTCGLog(log)
+		if err == nil {
+			if logLen == 0 {
+				t.Fatalf("Expected positive TCGLog length")
+			}
+			return
+		}
+		if err != ErrInsufficientBuffer {
+			t.Fatalf("GetTCGLog failed: err = %v", err)
+		}
+		log = append(log, make([]byte, len(log))...)
+	}
+}
+
+// Get the log by passing in nil, checking the size, and then getting the log.
+func TestGetLogWithNilSlice(t *testing.T) {
+	ctx := getContext(t)
+	defer ctx.Close()
+
+	logLen, err := ctx.GetTCGLog(nil)
+	if err != ErrInsufficientBuffer {
+		t.Fatalf("First GetTCGLog failed: err = %v", err)
+	}
+	if logLen == 0 {
+		t.Fatalf("Expected positive TCGLog length")
+	}
+
+	log := make([]byte, logLen)
+	if _, err := ctx.GetTCGLog(log); err != nil {
+		t.Fatalf("Second GetTCGLog failed: err = %v", err)
+	}
+}

--- a/tpmutil/tbs/tbs_windows_test.go
+++ b/tpmutil/tbs/tbs_windows_test.go
@@ -1,19 +1,28 @@
 package tbs
 
 import (
+	"bytes"
 	"os"
 	"testing"
+)
+
+
+var (
+	// Encodes a call to Getrandom with a length of 0
+	encodedCommand = []byte{128, 1, 0, 0, 0, 12, 0, 0, 1, 123, 0, 0}
+	// Expected response buffer for the above command
+	expectedResponse = []byte{128, 1, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0}
 )
 
 func getContext(t *testing.T) Context {
 	ctx, err := CreateContext(TPMVersion20, IncludeTPM12|IncludeTPM20)
 	if err != nil {
-		t.Fatalf("Could not get tbs.Context: %v", err)
+		t.Skipf("Skipping test as we couldn't access the TPM: %v", err)
 	}
 	return ctx
 }
 
-// Get the log by passing in progressivly larger buffers
+// Get the log by passing in progressively larger buffers
 func TestGetLogLargeBuffer(t *testing.T) {
 	ctx := getContext(t)
 	defer ctx.Close()
@@ -23,14 +32,14 @@ func TestGetLogLargeBuffer(t *testing.T) {
 		logLen, err := ctx.GetTCGLog(log)
 		if err == nil {
 			if logLen == 0 {
-				t.Fatalf("Expected positive TCGLog length")
+				t.Fatal("Expected positive TCGLog length")
 			}
 			return
 		}
 		if err != ErrInsufficientBuffer {
 			t.Fatalf("GetTCGLog failed: err = %v", err)
 		}
-		log = append(log, make([]byte, len(log))...)
+		log = make([]byte, 2*len(log))
 	}
 }
 
@@ -40,15 +49,66 @@ func TestGetLogWithNilSlice(t *testing.T) {
 	defer ctx.Close()
 
 	logLen, err := ctx.GetTCGLog(nil)
-	if err != ErrInsufficientBuffer {
+	if err != nil {
 		t.Fatalf("First GetTCGLog failed: err = %v", err)
 	}
 	if logLen == 0 {
-		t.Fatalf("Expected positive TCGLog length")
+		t.Fatal("Expected positive TCGLog length")
 	}
 
 	log := make([]byte, logLen)
 	if _, err := ctx.GetTCGLog(log); err != nil {
 		t.Fatalf("Second GetTCGLog failed: err = %v", err)
+	}
+}
+
+// Make sure SubmitCommand can handle a nil command buffer.
+func TestSubmitCommandNilCommand(t *testing.T) {
+	ctx := getContext(t)
+	defer ctx.Close()
+
+	response := make([]byte, os.Getpagesize())
+	_, err := ctx.SubmitCommand(NormalPriority, nil, response)
+	if err != ErrBadParameter {
+		t.Fatalf("Expected ErrBadParameter from Submit Command: got %v", err)
+	}
+}
+
+// Make sure SubmitCommand can handle a nil response buffer.
+func TestSubmitCommandNilResponse(t *testing.T) {
+	ctx := getContext(t)
+	defer ctx.Close()
+
+	_, err := ctx.SubmitCommand(NormalPriority, encodedCommand, nil)
+	if err != ErrInvalidOutputPointer {
+		t.Fatalf("Expected ErrInvalidOutputPointer from Submit Command: got %v", err)
+	}
+}
+
+// Make sure SubmitCommand can handle a short response buffer.
+func TestSubmitCommandShortResponse(t *testing.T) {
+	ctx := getContext(t)
+	defer ctx.Close()
+
+	response := make([]byte, 1)
+	_, err := ctx.SubmitCommand(NormalPriority, encodedCommand, response)
+	if err != ErrInsufficientBuffer {
+		t.Fatalf("Expected ErrInsufficientBuffer from Submit Command: got %v", err)
+	}
+}
+
+// Make sure SubmitCommand can handle a long response buffer.
+func TestSubmitCommandLongResponse(t *testing.T) {
+	ctx := getContext(t)
+	defer ctx.Close()
+
+	response := make([]byte, 100)
+	responseLen, err := ctx.SubmitCommand(NormalPriority, encodedCommand, response)
+	if err != nil {
+		t.Fatalf("SubmitCommand failed: err = %v", err)
+	}
+	response = response[:responseLen]
+	if !bytes.Equal(response, expectedResponse) {
+		t.Fatalf("Got response of %v, expected %v", response, expectedResponse)
 	}
 }


### PR DESCRIPTION
The existing code will panic if any nil slices are passed into the tpmutil/tbs library. This is especially bad as GetTCGLog has useful behavior if a zero length buffer is passed.

This change allows nil slices to be passed for all tbs methods. It also tests that we can get the TCG log by either
  - passing in a progressivly larger buffer
  - passing in nil to get the exact size

We also update the documentation to describe exactly what happens when a nil slice is passed. Microsoft's documentation is incomple, all the relevant parameters just say "TBD", see https://github.com/MicrosoftDocs/feedback/issues/551.

Finally, I added tests to make sure that the documented behavior actually happens.
Here's the tpmutil/tbs test output for a GCE VM:
```
PS C:\Users\magendanz\Documents\joe-go-tpm\tpmutil\tbs> go test -v
=== RUN   TestGetLogLargeBuffer
--- PASS: TestGetLogLargeBuffer (0.00s)         
=== RUN   TestGetLogWithNilSlice                
--- PASS: TestGetLogWithNilSlice (0.00s)        
=== RUN   TestSubmitCommandNilCommand           
--- PASS: TestSubmitCommandNilCommand (0.00s)   
=== RUN   TestSubmitCommandNilResponse          
--- PASS: TestSubmitCommandNilResponse (0.00s)  
=== RUN   TestSubmitCommandShortResponse        
--- PASS: TestSubmitCommandShortResponse (0.00s)
=== RUN   TestSubmitCommandLongResponse         
--- PASS: TestSubmitCommandLongResponse (0.03s) 
PASS
ok      _/C_/Users/magendanz/Documents/joe-go-tpm/tpmutil/tbs   0.114s 
```