### PR TITLE
add support for the Microsoft simulator format

### DIFF
--- a/tpm2/tpm2_linux_test.go
+++ b/tpm2/tpm2_linux_test.go
@@ -22,7 +22,7 @@ import (
 
 var tpmPath = flag.String("tpm_path", "", "Path to TPM character device. Most Linux systems expose it under /dev/tpm0. Empty value (default) will disable all integration tests.")
 
-func openTPM(t *testing.T) io.ReadWriteCloser {
+func openDeviceTPM(t *testing.T) io.ReadWriteCloser {
 	if *tpmPath == "" {
 		t.SkipNow()
 	}

--- a/tpm2/tpm2_windows_test.go
+++ b/tpm2/tpm2_windows_test.go
@@ -22,7 +22,7 @@ import (
 
 var runTPMTests = flag.Bool("run_tpm_tests", false, "Run the Windows TPM integration tests. Defaults to false.")
 
-func openTPM(t *testing.T) io.ReadWriteCloser {
+func openDeviceTPM(t *testing.T) io.ReadWriteCloser {
 	if *runTPMTests == false {
 		t.SkipNow()
 	}

--- a/tpmutil/mssim/mssim.go
+++ b/tpmutil/mssim/mssim.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2018, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mssim implements the Microsoft simulator TPM2 Transmission Interface
+//
+// The Microsoft simulator TPM Command Transmission Interface (TCTI) is a
+// remote procedure interface donated to the TPM2 Specification by Microsoft.
+// Its primary implementation is the tpm_server maintained by IBM.
+//
+// https://sourceforge.net/projects/ibmswtpm2/
+//
+// This package implements client code to communicate with server code described
+// in the document "TPM2 Specification Part 4: Supporting Routines – Code"
+//
+// https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-4-Supporting-Routines-01.38-code.pdf
+package mssim
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+)
+
+// Constants defined in "D.3.2. Typedefs and Defines"
+const (
+	tpmSignalPowerOn  uint32 = 1
+	tpmSignalPowerOff uint32 = 2
+	tpmSendCommand    uint32 = 8
+	tpmSignalNVOn     uint32 = 11
+	tpmSessionEnd     uint32 = 20
+)
+
+// Config holds configuration parameters for connecting to the simluator.
+type Config struct {
+	// Addresses of the command and platform handlers.
+	//
+	// Defaults to port 2321 and 2322 on localhost.
+	CommandAddress  string
+	PlatformAddress string
+}
+
+// Open creates connections to the simulator's command and platform ports and
+// power cycles the simulator to initialize it.
+func Open(config Config) (*Conn, error) {
+	cmdAddr := config.CommandAddress
+	if cmdAddr == "" {
+		cmdAddr = "127.0.0.1:2321"
+	}
+
+	platformAddr := config.PlatformAddress
+	if platformAddr == "" {
+		platformAddr = "127.0.0.1:2322"
+	}
+
+	conn, err := net.Dial("tcp", platformAddr)
+	if err != nil {
+		return nil, fmt.Errorf("dial platform address: %v", err)
+	}
+	defer conn.Close()
+
+	// Startup the simulator. This order of commands copies IBM's TPM2 tool's
+	// "powerup" command line tool and will reset the simulator.
+	//
+	// https://sourceforge.net/projects/ibmtpm20tss/
+
+	if err := sendPlatformCommand(conn, tpmSignalPowerOff); err != nil {
+		return nil, fmt.Errorf("power off platform command failed: %v", err)
+	}
+	if err := sendPlatformCommand(conn, tpmSignalPowerOn); err != nil {
+		return nil, fmt.Errorf("power on platform command failed: %v", err)
+	}
+	if err := sendPlatformCommand(conn, tpmSignalNVOn); err != nil {
+		return nil, fmt.Errorf("nv on platform command failed: %v", err)
+	}
+
+	// Gracefully close the connection.
+	if err := binary.Write(conn, binary.BigEndian, tpmSessionEnd); err != nil {
+		return nil, fmt.Errorf("shutdown platform connection failed: %v", err)
+	}
+
+	cmdConn, err := net.Dial("tcp", cmdAddr)
+	if err != nil {
+		return nil, fmt.Errorf("dial command address: %v", err)
+	}
+
+	return &Conn{conn: cmdConn}, nil
+}
+
+// sendPlatformCommand sends device management commands to the simulator.
+//
+// See: "D.4.3.2. PlatformServer()"
+func sendPlatformCommand(conn net.Conn, u uint32) error {
+	if err := binary.Write(conn, binary.BigEndian, u); err != nil {
+		return fmt.Errorf("write platform command: %v", err)
+	}
+
+	var rc uint32
+	if err := binary.Read(conn, binary.BigEndian, &rc); err != nil {
+		return fmt.Errorf("read platform command: %v", err)
+	}
+	if rc != 0 {
+		return fmt.Errorf("unexpected platform command response code: 0x%x", rc)
+	}
+	return nil
+}
+
+// Conn is a Microsoft Simulator client that can be used as a connection for the
+// tpm2 package.
+type Conn struct {
+	// Cached connection
+	conn net.Conn
+
+	// Response bytes left over from the previous read.
+	prevRead *bytes.Reader
+}
+
+// Read a response from the simulator. If the response is longer than the provided
+// buffer, the remainer will be cached for the next read.
+func (c *Conn) Read(b []byte) (int, error) {
+	if c.prevRead != nil && c.prevRead.Len() > 0 {
+		return c.prevRead.Read(b)
+	}
+
+	// Response frame:
+	// - uint32 (size of response)
+	// - []byte (response)
+	// - uint32 (always 0)
+	var respLen uint32
+	if err := binary.Read(c.conn, binary.BigEndian, &respLen); err != nil {
+		return 0, fmt.Errorf("read MS simulator response header: %v", err)
+	}
+
+	resp := make([]byte, int(respLen))
+	if _, err := io.ReadFull(c.conn, resp[:]); err != nil {
+		return 0, fmt.Errorf("read MS simulator response: %v", err)
+	}
+
+	var rc uint32
+	if err := binary.Read(c.conn, binary.BigEndian, &rc); err != nil {
+		return 0, fmt.Errorf("read MS simualtor return code: %v", err)
+	}
+	if rc != 0 {
+		return 0, fmt.Errorf("MS simulator returned invalid return code: 0x%x", rc)
+	}
+
+	c.prevRead = bytes.NewReader(resp)
+	return c.prevRead.Read(b)
+}
+
+// Write a raw command to the simulator. Commands must be written in a single call
+// to Write. Commands split over multiple calls will result in multiple framed
+// requests.
+func (c *Conn) Write(b []byte) (int, error) {
+	// See: D.4.3.12. TpmServer()
+	buff := &bytes.Buffer{}
+	// "send command" flag
+	binary.Write(buff, binary.BigEndian, tpmSendCommand)
+	// locality 0
+	buff.WriteByte(0)
+	// size of the command
+	binary.Write(buff, binary.BigEndian, uint32(len(b)))
+	// raw command
+	buff.Write(b)
+
+	if _, err := buff.WriteTo(c.conn); err != nil {
+		return 0, fmt.Errorf("write MS simulator command: %v", err)
+	}
+	return len(b), nil
+}
+
+// Close closes any outgoing connections to the TPM simulator.
+func (c *Conn) Close() error {
+	// See: D.4.3.12. TpmServer()
+	// Gracefully close the connection.
+	if err := binary.Write(c.conn, binary.BigEndian, tpmSessionEnd); err != nil {
+		c.conn.Close()
+		return fmt.Errorf("shutdown platform connection failed: %v", err)
+	}
+	return c.conn.Close()
+}


### PR DESCRIPTION
"mssim" is a transmission interface for the Microsoft simulator, which
is supported by TPM utilities such as tpm2-tool[1]. This RPC format
also goes by "socsim"[2].

The format was donated by Microsoft to the TPM2 specification, and is
primarily implemented by a simulator maintained by IBM[3]. This PR allows
go-tpm to interact with that simulator, and lets users run examples
without access to a real TPM2 device.

To run the tests, compile and run tpm_server[4].

```
$ tpm_server
TPM command server listening on port 2321
Platform server listening on port 2322
```

Then execute the following command. This PR currently passes many of the
integration tests, but fails on the following (I've not looked into why
yet):

```
$ go test github.com/google/go-tpm/tpm2 -args -mssim
--- FAIL: TestCombinedKeyTest (0.20s)
    tpm2_test.go:136: CreateKey failed: response status 0x921
--- FAIL: TestCombinedEndorsementTest (0.21s)
    tpm2_test.go:162: CreateKey failed: response status 0x921
--- FAIL: TestCombinedContextTest (0.26s)
    tpm2_test.go:205: CreateKey failed: response status 0x921
--- FAIL: TestEvictControl (0.29s)
    tpm2_test.go:239: CreateKey failed: response status 0x921
--- FAIL: TestCertify (0.31s)
    tpm2_test.go:375: Certify failed: response status 0x921
--- FAIL: TestCertifyExternalKey (0.79s)
    --- FAIL: TestCertifyExternalKey/RSA (0.50s)
        tpm2_test.go:479: Certify failed: response status 0x921
    --- FAIL: TestCertifyExternalKey/ECC (0.13s)
        tpm2_test.go:503: Certify failed: response status 0x921
--- FAIL: TestSign (0.33s)
    --- FAIL: TestSign/RSA (0.18s)
        tpm2_test.go:529: Sign failed: response status 0x921
    --- FAIL: TestSign/ECC (0.14s)
        tpm2_test.go:529: Sign failed: response status 0x921
--- FAIL: TestReadPCR (0.04s)
    tpm2_test.go:590: PCR 16 value missing from response
FAIL
FAIL    github.com/google/go-tpm/tpm2   3.332s
```

[1] https://github.com/tpm2-software/tpm2-tools/blob/master/man/common/tcti.md
[2] https://blog.hansenpartnership.com/tpm2-and-linux/
[3] https://sourceforge.net/projects/ibmswtpm2/
[4] https://github.com/tpm2-software/tpm2-tools/blob/master/INSTALL.md#tpm-simulator