### PR TITLE
Implement encode/decode of CreationData (TPMS_CREATION_DATA)

### DIFF
--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -545,31 +545,31 @@ func (cd *CreationData) encode() ([]byte, error) {
 
 // DecodeCreationData decodes a TPMS_CREATION_DATA message. No error is
 // returned if the input has extra trailing data.
-func DecodeCreationData(in []byte) (*CreationData, error) {
-	buf := bytes.NewBuffer(in)
+func DecodeCreationData(buf []byte) (*CreationData, error) {
+	in := bytes.NewBuffer(buf)
 	var out CreationData
 
-	sel, err := decodeTPMLPCRSelection(buf)
+	sel, err := decodeTPMLPCRSelection(in)
 	if err != nil {
 		return nil, fmt.Errorf("decoding PCRSelection: %v", err)
 	}
 	out.PCRSelection = sel
 
-	if err := tpmutil.UnpackBuf(buf, &out.PCRDigest, &out.Locality, &out.ParentNameAlg); err != nil {
+	if err := tpmutil.UnpackBuf(in, &out.PCRDigest, &out.Locality, &out.ParentNameAlg); err != nil {
 		return nil, fmt.Errorf("decoding PCRDigest, Locality, ParentNameAlg: %v", err)
 	}
 
-	n, err := decodeName(buf)
+	n, err := decodeName(in)
 	if err != nil {
 		return nil, fmt.Errorf("decoding ParentName: %v", err)
 	}
 	out.ParentName = *n
-	if n, err = decodeName(buf); err != nil {
+	if n, err = decodeName(in); err != nil {
 		return nil, fmt.Errorf("decoding ParentQualifiedName: %v", err)
 	}
 	out.ParentQualifiedName = *n
 
-	if err := tpmutil.UnpackBuf(buf, &out.OutsideInfo); err != nil {
+	if err := tpmutil.UnpackBuf(in, &out.OutsideInfo); err != nil {
 		return nil, fmt.Errorf("decoding OutsideInfo: %v", err)
 	}
 

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -91,7 +91,7 @@ func decodeTPMLPCRSelection(buf *bytes.Buffer) (PCRSelection, error) {
 	case 0:
 		sel.Hash = AlgUnknown
 		return sel, nil
-	case 1:
+	case 1: // We only support decoding of a single PCRSelection.
 	default:
 		return sel, fmt.Errorf("decoding TPML_PCR_SELECTION list longer than 1 is not supported (got length %d)", count)
 	}

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -87,7 +87,12 @@ func decodeTPMLPCRSelection(buf *bytes.Buffer) (PCRSelection, error) {
 	if err := tpmutil.UnpackBuf(buf, &count); err != nil {
 		return sel, err
 	}
-	if count != 1 {
+	switch count {
+	case 0:
+		sel.Hash = AlgUnknown
+		return sel, nil
+	case 1:
+	default:
 		return sel, fmt.Errorf("decoding TPML_PCR_SELECTION list longer than 1 is not supported (got length %d)", count)
 	}
 

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -644,3 +644,36 @@ func TestEncodeDecodeAttestationData(t *testing.T) {
 		t.Errorf("got decoded value:\n%v\nwant:\n%v", decoded, ad)
 	}
 }
+
+func TestEncodeDecodeCreationData(t *testing.T) {
+	parentQualified := tpmutil.Handle(101)
+	cd := CreationData{
+		PCRSelection:  PCRSelection{Hash: AlgSHA1, PCRs: []int{7}},
+		PCRDigest:     []byte{1, 2, 3},
+		Locality:      32,
+		ParentNameAlg: AlgSHA1,
+		ParentName: Name{
+			Digest: &HashValue{
+				Alg:   AlgSHA1,
+				Value: make([]byte, hashConstructors[AlgSHA1]().Size()),
+			},
+		},
+		ParentQualifiedName: Name{
+			Handle: &parentQualified,
+		},
+		OutsideInfo: []byte{7, 8, 9},
+	}
+
+	encoded, err := cd.encode()
+	if err != nil {
+		t.Fatalf("error encoding CreationData: %v", err)
+	}
+	decoded, err := DecodeCreationData(encoded)
+	if err != nil {
+		t.Fatalf("error decoding CreationData: %v", err)
+	}
+
+	if !reflect.DeepEqual(*decoded, cd) {
+		t.Errorf("got decoded value:\n%v\nwant:\n%v", decoded, cd)
+	}
+}


### PR DESCRIPTION
In addition, support decode of TPML_PCR_SELECTION structure of length 0.

DecodeCreationData has been tested on real hardware, compliant with Microsoft requirements for Windows 10.