### PR TITLE
ECC capability check

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -68,6 +68,15 @@ const (
 	AlgECB       Algorithm = 0x0044
 )
 
+// AlgorithmAttributes represents a TPMA_ALGORITHM value.
+type AlgorithmAttributes uint32
+
+// AlgorithmDescription represents a TPMS_ALGORITHM_DESCRIPTION structure.
+type AlgorithmDescription struct {
+	ID         Algorithm
+	Attributes AlgorithmAttributes
+}
+
 // SessionType defines the type of session created in StartAuthSession.
 type SessionType uint8
 

--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -68,15 +68,6 @@ const (
 	AlgECB       Algorithm = 0x0044
 )
 
-// AlgorithmAttributes represents a TPMA_ALGORITHM value.
-type AlgorithmAttributes uint32
-
-// AlgorithmDescription represents a TPMS_ALGORITHM_DESCRIPTION structure.
-type AlgorithmDescription struct {
-	ID         Algorithm
-	Attributes AlgorithmAttributes
-}
-
 // SessionType defines the type of session created in StartAuthSession.
 type SessionType uint8
 

--- a/tpm2/encoding_test.go
+++ b/tpm2/encoding_test.go
@@ -69,12 +69,12 @@ func TestDecodeGetCapability(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	capReported, handles, err := decodeGetCapability(testRespBytes[10:])
+	capReported, handles, moreData, err := decodeGetCapability(testRespBytes[10:])
 	if err != nil {
 		t.Fatal(err)
 	}
-	if capReported != CapabilityHandles || len(handles) != 0 {
-		t.Fatalf("got: (%v, %v), want: (%v, %v)", capReported, handles, CapabilityHandles, 0)
+	if capReported != CapabilityHandles || len(handles) != 0 || moreData {
+		t.Fatalf("got: (%v, %v, %v), want: (%v, %v, %v)", capReported, handles, moreData, CapabilityHandles, 0, false)
 	}
 }
 

--- a/tpm2/encoding_test.go
+++ b/tpm2/encoding_test.go
@@ -69,12 +69,12 @@ func TestDecodeGetCapability(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	capReported, handles, moreData, err := decodeGetCapability(testRespBytes[10:])
+	handles, moreData, err := decodeGetCapability(testRespBytes[10:])
 	if err != nil {
 		t.Fatal(err)
 	}
-	if capReported != CapabilityHandles || len(handles) != 0 || moreData {
-		t.Fatalf("got: (%v, %v, %v), want: (%v, %v, %v)", capReported, handles, moreData, CapabilityHandles, 0, false)
+	if len(handles) != 0 || moreData {
+		t.Fatalf("got: (%v, %v), want: (%v, %v)", handles, moreData, 0, false)
 	}
 }
 

--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -750,3 +750,12 @@ type ClockInfo struct {
 	RestartCount uint32
 	Safe         byte
 }
+
+// AlgorithmAttributes represents a TPMA_ALGORITHM value.
+type AlgorithmAttributes uint32
+
+// AlgorithmDescription represents a TPMS_ALGORITHM_DESCRIPTION structure.
+type AlgorithmDescription struct {
+	ID         Algorithm
+	Attributes AlgorithmAttributes
+}

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -188,49 +188,62 @@ func ReadClock(rw io.ReadWriter) (uint64, uint64, error) {
 	return decodeReadClock(resp)
 }
 
-func decodeGetCapability(in []byte) (Capability, []tpmutil.Handle, error) {
+func decodeGetCapability(in []byte) (Capability, []interface{}, bool, error) {
 	var moreData byte
 	var capReported Capability
 
 	buf := bytes.NewBuffer(in)
 	if err := tpmutil.UnpackBuf(buf, &moreData, &capReported); err != nil {
-		return 0, nil, err
-	}
-	// Only TPM_CAP_HANDLES handled.
-	if capReported != CapabilityHandles {
-		return 0, nil, fmt.Errorf("Only TPM_CAP_HANDLES supported, got %v", capReported)
+		return capReported, nil, false, err
 	}
 
-	var numHandles uint32
-	if err := tpmutil.UnpackBuf(buf, &numHandles); err != nil {
-		return 0, nil, err
-	}
-
-	var handles []tpmutil.Handle
-	for i := 0; i < int(numHandles); i++ {
-		var handle tpmutil.Handle
-		if err := tpmutil.UnpackBuf(buf, &handle); err != nil {
-			return 0, nil, err
+	switch capReported {
+	case CapabilityHandles:
+		var numHandles uint32
+		if err := tpmutil.UnpackBuf(buf, &numHandles); err != nil {
+			return capReported, nil, false, fmt.Errorf("could not unpack handle count: %v", err)
 		}
-		handles = append(handles, handle)
-	}
 
-	return capReported, handles, nil
+		var handles []interface{}
+		for i := 0; i < int(numHandles); i++ {
+			var handle tpmutil.Handle
+			if err := tpmutil.UnpackBuf(buf, &handle); err != nil {
+				return capReported, nil, false, fmt.Errorf("could not unpack handle: %v", err)
+			}
+			handles = append(handles, handle)
+		}
+		return capReported, handles, moreData > 0, nil
+	case CapabilityAlgs:
+		var numAlgs uint32
+		if err := tpmutil.UnpackBuf(buf, &numAlgs); err != nil {
+			return capReported, nil, false, fmt.Errorf("could not unpack algorithm count: %v", err)
+		}
+
+		var algs []interface{}
+		for i := 0; i < int(numAlgs); i++ {
+			var alg AlgorithmDescription
+			if err := tpmutil.UnpackBuf(buf, &alg); err != nil {
+				return capReported, nil, false, fmt.Errorf("could not unpack algorithm description: %v", err)
+			}
+			algs = append(algs, alg)
+		}
+		return capReported, algs, moreData > 0, nil
+	default:
+		return capReported, nil, false, fmt.Errorf("unsupported capability %v", capReported)
+	}
 }
 
 // GetCapability returns various information about the TPM state.
 //
-// Currently only CapabilityHandles is supported (list active handles).
-func GetCapability(rw io.ReadWriter, cap Capability, count uint32, property uint32) ([]tpmutil.Handle, error) {
-	resp, err := runCommand(rw, TagNoSessions, cmdGetCapability, cap, property, count)
+// Currently only CapabilityHandles (list active handles) and CapabilityAlgs
+// (list supported algorithms) are supported.
+func GetCapability(rw io.ReadWriter, capa Capability, count uint32, property uint32) (vals []interface{}, moreData bool, err error) {
+	resp, err := runCommand(rw, TagNoSessions, cmdGetCapability, capa, property, count)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	_, handles, err := decodeGetCapability(resp)
-	if err != nil {
-		return nil, err
-	}
-	return handles, nil
+	_, vals, moreData, err = decodeGetCapability(resp)
+	return vals, moreData, err
 }
 
 func encodeAuthArea(sessionHandle tpmutil.Handle, passwords ...string) ([]byte, error) {

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -302,9 +302,9 @@ func TestHash(t *testing.T) {
 }
 
 func skipOnUnsupportedAlg(t *testing.T, rw io.ReadWriter, alg Algorithm) {
-	var err error
 	moreData := true
 	for i := uint32(0); moreData; i++ {
+		var err error
 		var descs []interface{}
 		descs, moreData, err = GetCapability(rw, CapabilityAlgs, 1, i)
 		if err != nil {

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -125,8 +125,17 @@ func TestGetCapability(t *testing.T) {
 	rw := openTPM(t)
 	defer rw.Close()
 
-	if _, err := GetCapability(rw, CapabilityHandles, 1, 0x80000000); err != nil {
-		t.Fatalf("GetCapability failed: %s", err)
+	for _, tt := range []struct {
+		capa     Capability
+		count    uint32
+		property uint32
+	}{
+		{CapabilityHandles, 1, 0x80000000},
+		{CapabilityAlgs, 1, 0},
+	} {
+		if _, _, err := GetCapability(rw, tt.capa, tt.count, tt.property); err != nil {
+			t.Fatalf("GetCapability(%v, %d, %d) = _, %v; want _, nil", tt.capa, tt.count, tt.property, err)
+		}
 	}
 }
 


### PR DESCRIPTION
I tried go-tpm on Intel PTT and got met with 0x1ca errors (value not appropriate) when the ECC functionality was checked. So I added a possibility to query the algorithm descriptions through GetCapability and used that in the unit test to check for a supported TPM. I'm not entirely happy with it as the latter should actually be a more generic function to check for an algorithm's presence but I guess it's a start. My apologies for potentially adhering too strongly to the internal coding style in this change.

Alternatively I suspect one could also just check for 0x1ca, but that seems sort of hacky. :)