### PR TITLE
Implement UseContext, so we can use contexts provided by windows APIs with this library

### DIFF
--- a/tpmutil/run_windows.go
+++ b/tpmutil/run_windows.go
@@ -74,11 +74,11 @@ func OpenTPM() (io.ReadWriteCloser, error) {
 	return rwc, err
 }
 
-// UseContext creates a new instance of a ReadWriteCloser which can
+// FromContext creates a new instance of a ReadWriteCloser which can
 // interact with a Windows TPM, using the specified TBS handle.
-func UseContext(tpmContext tbs.Context) io.ReadWriteCloser {
+func FromContext(ctx tbs.Context) io.ReadWriteCloser {
 	return &winTPMBuffer{
-		context:   tpmContext,
+		context:   ctx,
 		outBuffer: make([]byte, 0, maxTPMResponse),
 	}
 }

--- a/tpmutil/run_windows.go
+++ b/tpmutil/run_windows.go
@@ -73,3 +73,12 @@ func OpenTPM() (io.ReadWriteCloser, error) {
 	}
 	return rwc, err
 }
+
+// UseContext creates a new instance of a ReadWriteCloser which can
+// interact with a Windows TPM, using the specified TBS handle.
+func UseContext(tpmContext tbs.Context) io.ReadWriteCloser {
+	return &winTPMBuffer{
+		context:   tpmContext,
+		outBuffer: make([]byte, 0, maxTPMResponse),
+	}
+}


### PR DESCRIPTION
If you are using an AIK/key managed by Microsoft Platform Crypto Provider, you can call `NCryptGetProperty` with `NCRYPT_PCP_PLATFORMHANDLE_PROPERTY` to get a TBS context you can use with this library, and call the same on the key to get a TPM handle valid for that context. That allows you to invoke arbitrary TPM commands using a Windows-managed key.

This function allows us to construct a ReadWriteCloser to use with the rest of the go-tpm.