### PR TITLE
Implement CreatePrimaryEx(), refactor CreatePrimary()

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -221,6 +221,7 @@ const (
 	cmdStirRandom         tpmutil.Command = 0x00000146
 	cmdActivateCredential tpmutil.Command = 0x00000147
 	cmdCertify            tpmutil.Command = 0x00000148
+	cmdCertifyCreation    tpmutil.Command = 0x0000014A
 	cmdReadNV             tpmutil.Command = 0x0000014E
 	cmdCreate             tpmutil.Command = 0x00000153
 	cmdLoad               tpmutil.Command = 0x00000157

--- a/tpm2/encoding_test.go
+++ b/tpm2/encoding_test.go
@@ -203,7 +203,7 @@ func TestDecodeCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, _, err = decodeCreate(testRespBytes[10:]); err != nil {
+	if _, err = decodeCreate(testRespBytes[10:]); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tpm2/encoding_test.go
+++ b/tpm2/encoding_test.go
@@ -154,7 +154,7 @@ func TestDecodeCreatePrimary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, _, err = decodeCreatePrimary(testRespBytes[10:]); err != nil {
+	if _, _, _, _, _, _, err = decodeCreatePrimary(testRespBytes[10:]); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tpm2/encoding_test.go
+++ b/tpm2/encoding_test.go
@@ -203,7 +203,7 @@ func TestDecodeCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err = decodeCreate(testRespBytes[10:]); err != nil {
+	if _, _, _, _, _, _, err = decodeCreate(testRespBytes[10:]); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -792,3 +792,28 @@ type AlgorithmDescription struct {
 	ID         Algorithm
 	Attributes AlgorithmAttributes
 }
+
+// Ticket represents evidence the TPM previously processed
+// information.
+type Ticket struct {
+	Type      tpmutil.Tag
+	Hierarchy uint32
+	Digest    []byte
+}
+
+// Encode represents the given values as a Ticket.
+func (t Ticket) Encode() ([]byte, error) {
+	return tpmutil.Pack(t.Type, t.Hierarchy, t.Digest)
+}
+
+func (t Ticket) packedSize() int {
+	return /* tag */ 2 + /* hierarchy */ 4 + /* digest length */ 2 + len(t.Digest)
+}
+
+func decodeTicket(in []byte) (*Ticket, error) {
+	var t Ticket
+	if _, err := tpmutil.Unpack(in, &t.Type, &t.Hierarchy, &t.Digest); err != nil {
+		return nil, fmt.Errorf("decoding Type, Hierarchy, Digest: %v", err)
+	}
+	return &t, nil
+}

--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -801,18 +801,14 @@ type Ticket struct {
 	Digest    []byte
 }
 
-// Encode represents the given values as a Ticket.
+// Encode represents the Ticket into TPM wire format.
 func (t Ticket) Encode() ([]byte, error) {
 	return tpmutil.Pack(t.Type, t.Hierarchy, t.Digest)
 }
 
-func (t Ticket) packedSize() int {
-	return /* tag */ 2 + /* hierarchy */ 4 + /* digest length */ 2 + len(t.Digest)
-}
-
-func decodeTicket(in []byte) (*Ticket, error) {
+func decodeTicket(in *bytes.Buffer) (*Ticket, error) {
 	var t Ticket
-	if _, err := tpmutil.Unpack(in, &t.Type, &t.Hierarchy, &t.Digest); err != nil {
+	if err := tpmutil.UnpackBuf(in, &t.Type, &t.Hierarchy, &t.Digest); err != nil {
 		return nil, fmt.Errorf("decoding Type, Hierarchy, Digest: %v", err)
 	}
 	return &t, nil

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -551,17 +551,6 @@ func doCreate(rw io.ReadWriter, parentHandle tpmutil.Handle, parentPassword, obj
 	return decodeCreate(resp)
 }
 
-// Create creates a new key pair under the owner handle.
-// Unlike CreateKey(), all information recieved back from the
-// TPM is returned.
-func Create(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection, parentPassword, ownerPassword string, pub Public) ([]byte, []byte, []byte, []byte, Ticket, error) {
-	resp, err := doCreate(rw, owner, parentPassword, ownerPassword, nil /*inSensitive*/, pub, sel)
-	if err != nil {
-		return nil, nil, nil, nil, Ticket{}, err
-	}
-	return resp.Private, resp.Public, resp.CreationData, resp.CreationHash, resp.CreationTicket, nil
-}
-
 // CreateKey creates a new key pair under the owner handle.
 // Returns private key and public key blobs.
 func CreateKey(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection, parentPassword, ownerPassword string, pub Public) ([]byte, []byte, error) {

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -172,65 +172,6 @@ func TestCombinedKeyTest(t *testing.T) {
 	}
 }
 
-func TestCreateAndCertifyCreation(t *testing.T) {
-	rw := openTPM(t)
-	defer rw.Close()
-
-	params := Public{
-		Type:       AlgRSA,
-		NameAlg:    AlgSHA256,
-		Attributes: FlagFixedTPM | FlagFixedParent | FlagSensitiveDataOrigin | FlagRestricted | FlagSign | FlagNoDA | FlagUserWithAuth,
-		AuthPolicy: nil,
-		RSAParameters: &RSAParams{
-			Sign: &SigScheme{
-				Alg:  AlgRSASSA,
-				Hash: AlgSHA256,
-			},
-			KeyBits: 2048,
-			Modulus: big.NewInt(0),
-		},
-	}
-
-	keyHandle, pub, _, creationHash, tix, _, err := CreatePrimaryEx(rw, HandleEndorsement, pcrSelection, emptyPassword, emptyPassword, params)
-	if err != nil {
-		t.Fatalf("CreatePrimary 2 failed: %s", err)
-	}
-	defer FlushContext(rw, keyHandle)
-
-	attestation, signature, err := CertifyCreation(rw, emptyPassword, keyHandle, keyHandle, nil, creationHash, tix)
-	if err != nil {
-		t.Fatalf("CertifyCreation failed: %s", err)
-	}
-	att, err := DecodeAttestationData(attestation)
-	if err != nil {
-		t.Fatalf("DecodeAttestationData(%v) returned error: %v", attestation, err)
-	}
-	if att.Type != TagAttestCreation {
-		t.Errorf("Expected attestation structure to be of type TagAttestCreation, got %v", att.Type)
-	}
-
-	p, err := DecodePublic(pub)
-	if err != nil {
-		t.Fatalf("DecodePublic returned err: %v", err)
-	}
-	match, err := att.AttestedCreationInfo.Name.MatchesPublic(p)
-	if err != nil {
-		t.Fatalf("MatchesPublic returned err: %v", err)
-	}
-	if !match {
-		t.Error("Attested name does not match returned public key.")
-		t.Logf("Name: %v", att.AttestedCreationInfo.Name)
-		t.Logf("Public: %v", p)
-	}
-
-	rsaPub := rsa.PublicKey{E: int(p.RSAParameters.Exponent), N: p.RSAParameters.Modulus}
-	hsh := crypto.SHA256.New()
-	hsh.Write(attestation)
-	if err := rsa.VerifyPKCS1v15(&rsaPub, crypto.SHA256, hsh.Sum(nil), signature); err != nil {
-		t.Errorf("Signature failed to verify: %v", err)
-	}
-}
-
 func TestCombinedEndorsementTest(t *testing.T) {
 	rw := openTPM(t)
 	defer rw.Close()

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -287,7 +287,10 @@ func TestCreatePrimaryEx(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadPublic failed: %s", err)
 	}
-	pub2, _ := pub.Encode()
+	pub2, err := pub.Encode()
+	if err != nil {
+		t.Fatalf("Failed to encode public: %v", err)
+	}
 
 	if !bytes.Equal(pub1, pub2) {
 		t.Error("Mismatch between public returned from CreatePrimaryEx() & ReadPublic()")


### PR DESCRIPTION
This implements primitives necessary for remote key attestation for an AIK.

As discussed with awly@, most parameters returned from `CreatePrimaryEx()` are raw byte slices. This is easier to use for their intended use case (remote key attestation), users who just want a primary key have everything they need from `CreatePrimary()` already.