### PR TITLE
Fix + extend NVRead(), CapabilityTPMProperties support to GetCapability()

### DIFF
--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -793,6 +793,15 @@ type AlgorithmDescription struct {
 	Attributes AlgorithmAttributes
 }
 
+// PropertyTag represents a TPM_PT value.
+type PropertyTag uint32
+
+// TaggedProperty represents a TPMS_TAGGED_PROPERTY structure.
+type TaggedProperty struct {
+	Tag   PropertyTag
+	Value uint32
+}
+
 // Ticket represents evidence the TPM previously processed
 // information.
 type Ticket struct {

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -133,6 +133,7 @@ func TestGetCapability(t *testing.T) {
 	}{
 		{CapabilityHandles, 1, 0x80000000, tpmutil.Handle(0)},
 		{CapabilityAlgs, 1, 0, AlgorithmDescription{}},
+		{CapabilityTPMProperties, 1, 0x100 + 44, TaggedProperty{}},
 	} {
 		l, _, err := GetCapability(rw, tt.capa, tt.count, tt.property)
 		if err != nil {
@@ -928,5 +929,16 @@ func TestCreateAndCertifyCreation(t *testing.T) {
 	hsh.Write(attestation)
 	if err := rsa.VerifyPKCS1v15(&rsaPub, crypto.SHA256, hsh.Sum(nil), signature); err != nil {
 		t.Errorf("VerifyPKCS1v15 failed: %v", err)
+	}
+}
+
+func TestNVRead(t *testing.T) {
+	rw := openTPM(t)
+	defer rw.Close()
+
+	// Read the NVCert, which should be present on any real TPM.
+	_, err := NVRead(rw, 0x1c00002)
+	if err != nil {
+		t.Fatalf("NVRead() failed: %v", err)
 	}
 }


### PR DESCRIPTION
There are a few issues with `NVRead()`:

 * Doesn't understand the concept of buffer sizes, meaning any NVRAM value that is too large for the TPM's buffer will not be readable. The spec mentions that reads should be done in blocks of `TPM_PT_NV_BUFFER_MAX`, which we do.
 * Doesn't support authorizing the read using `HandleOwner` or `HandlePlatform`. We fix this with `NVReadEx`, which also supports specifying `TPM_PT_NV_BUFFER_MAX` if the user has already read it (to avoid additional reads).

I've hardcoded the constant for `TPM_PT_NV_BUFFER_MAX` in tpm2.go. Let me know if this should be in constants.go (I dont want to put the full massive list of CapabilitiesTPMProperties in there, so have avoided doing this so far).