### PR TITLE
Fix NVRead and Add NVReadPublic / NVReadAll

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -273,3 +273,42 @@ var hashConstructors = map[Algorithm]func() hash.Hash{
 	AlgSHA384: sha512.New384,
 	AlgSHA512: sha512.New,
 }
+
+// NVAttr is a bitmask used in Attributes field of NV indexes. Individual
+// flags should be OR-ed to form a full mask.
+type NVAttr uint32
+
+const (
+	AttrPPWrite NVAttr = 1 << iota
+	AttrOwnerWrite
+	AttrAuthWrite
+	AttrPolicyWrite
+	_
+	_
+	_
+	_
+	_
+	_
+	AttrPolicyDelete
+	AttrWriteLocked
+	AttrWriteAll
+	AttrWriteDefine
+	AttrWriteSTClear
+	AttrGlobalLock
+	AttrPPRead
+	AttrOwnerRead
+	AttrAuthRead
+	AttrPolicyRead
+	_
+	_
+	_
+	_
+	_
+	AttrNoDA
+	AttrOrderly
+	AttrClearSTClear
+	AttrReadLocked
+	AttrWritten
+	AttrPlatformCreate
+	AttrReadSTClear
+)


### PR DESCRIPTION
As discussed in https://github.com/google/go-tpm/pull/52 this PR:

- Corrects NVRead with owner, offset and size as per spec
- Exposes NVReadPublic
- Adds a covenience function `NVReadAll` to implement the old behavior (read all data from an index)
- Updates the NVWrite test to include NVRead for validation

Since it changes the function calls, this is a breaking change.

If you prefer hex values for the attribute bitmaps, I can change the PR.