### PR TITLE
Spelling

### DIFF
--- a/examples/tpm-takeownership/own.go
+++ b/examples/tpm-takeownership/own.go
@@ -53,13 +53,13 @@ func main() {
 		copy(srkAuth[:], sa[:])
 	}
 
-	pubek, err := tpm.ReadPubEK(rwc)
+	pubEK, err := tpm.ReadPubEK(rwc)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't read the endorsement key: %s\n", err)
 		return
 	}
 
-	if err := tpm.TakeOwnership(rwc, ownerAuth, srkAuth, pubek); err != nil {
+	if err := tpm.TakeOwnership(rwc, ownerAuth, srkAuth, pubEK); err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't take ownership of the TPM: %s\n", err)
 		return
 	}

--- a/tpm/commands.go
+++ b/tpm/commands.go
@@ -178,7 +178,7 @@ func quote2(rw io.ReadWriter, keyHandle tpmutil.Handle, hash [20]byte, pcrs *pcr
 }
 
 // quote performs a TPM 1.1 quote operation: it signs data using the
-// TPM_QUOTE_INFO structure for the current values of a selectied set of PCRs.
+// TPM_QUOTE_INFO structure for the current values of a selected set of PCRs.
 func quote(rw io.ReadWriter, keyHandle tpmutil.Handle, hash [20]byte, pcrs *pcrSelection, ca *commandAuth) (*pcrComposite, []byte, *responseAuth, uint32, error) {
 	in := []interface{}{keyHandle, hash, pcrs, ca}
 	var pcrc pcrComposite

--- a/tpm/errors.go
+++ b/tpm/errors.go
@@ -118,7 +118,7 @@ const (
 	errDAAIssuerSettings
 	errDAASettings
 	errDAAState
-	errDAAIssuerVailidity
+	errDAAIssuerValidity
 	errDAAWrongW
 	errBadHandle
 	errBadDelegate
@@ -220,7 +220,7 @@ var tpmErrMsgs = map[tpmError]string{
 	errDAAIssuerSettings:     "the consistency check on DAA_issuerSettings has failed",
 	errDAASettings:           "the consistency check on DAA_tpmSpecific has failed",
 	errDAAState:              "the atomic process indicated by the submitted DAA command is not the expected process",
-	errDAAIssuerVailidity:    "the issuer's validity check has detected an inconsistency",
+	errDAAIssuerValidity:    "the issuer's validity check has detected an inconsistency",
 	errDAAWrongW:             "the consistency check on w has failed",
 	errBadHandle:             "the handle is incorrect",
 	errBadDelegate:           "delegation is not correct",

--- a/tpm/errors.go
+++ b/tpm/errors.go
@@ -82,7 +82,7 @@ const (
 	errNoWrapTransport
 	errAuditFailUnsuccessful
 	errAuditFailSuccessful
-	errNotResetable
+	errNotResettable
 	errNotLocal
 	errBadType
 	errInvalidResource
@@ -184,7 +184,7 @@ var tpmErrMsgs = map[tpmError]string{
 	errNoWrapTransport:       "the TPM does not allow for wrapped transport sessions",
 	errAuditFailUnsuccessful: "TPM audit construction failed and the underlying command was returning a failure code also",
 	errAuditFailSuccessful:   "TPM audit construction failed and the underlying command was returning success",
-	errNotResetable:          "attempt to reset a PCR register that does not have the resettable attribute",
+	errNotResettable:          "attempt to reset a PCR register that does not have the resettable attribute",
 	errNotLocal:              "attempt to reset a PCR register that requires locality and locality modifier not part of command transport",
 	errBadType:               "make identity blob not properly typed",
 	errInvalidResource:       "when saving context identified resource type does not match actual resource",

--- a/tpm/errors.go
+++ b/tpm/errors.go
@@ -108,7 +108,7 @@ const (
 	errNoOperator
 	errResourceMissing
 	errDelegateLock
-	errDelegateFamliy
+	errDelegateFamily
 	errDelegateAdmin
 	errTransportNotExclusive
 	errOwnerControl
@@ -210,7 +210,7 @@ var tpmErrMsgs = map[tpmError]string{
 	errNoOperator:            "no operator AuthData value is set",
 	errResourceMissing:       "the resource pointed to by context is not loaded",
 	errDelegateLock:          "the delegate administration is locked",
-	errDelegateFamliy:        "attempt to manage a family other than the delegated family",
+	errDelegateFamily:        "attempt to manage a family other than the delegated family",
 	errDelegateAdmin:         "delegation table management not enabled",
 	errTransportNotExclusive: "there was a command executed outside of an exclusive transport session",
 	errOwnerControl:          "attempt to context save a owner evict controlled key",

--- a/tpm/structures.go
+++ b/tpm/structures.go
@@ -69,7 +69,7 @@ type pcrInfo struct {
 
 // A capVersionInfo contains information about the TPM itself. Note that this
 // is deserialized specially, since it has a variable-length byte array but no
-// length. It is preceeded with a length in the response to the Quote2 command.
+// length. It is preceded with a length in the response to the Quote2 command.
 type capVersionInfo struct {
 	CapVersionFixed capVersionInfoFixed
 	VendorSpecific  []byte

--- a/tpm/structures.go
+++ b/tpm/structures.go
@@ -188,23 +188,23 @@ func (ra responseAuth) String() string {
 }
 
 // These are the parameters of a TPM key.
-type keyParms struct {
+type keyParams struct {
 	AlgID     uint32
 	EncScheme uint16
 	SigScheme uint16
-	Parms     []byte // Serialized rsaKeyParms or symmetricKeyParms.
+	Params     []byte // Serialized rsaKeyParams or symmetricKeyParams.
 }
 
-// An rsaKeyParms encodes the length of the RSA prime in bits, the number of
+// An rsaKeyParams encodes the length of the RSA prime in bits, the number of
 // primes in its factored form, and the exponent used for public-key
 // encryption.
-type rsaKeyParms struct {
+type rsaKeyParams struct {
 	KeyLength uint32
 	NumPrimes uint32
 	Exponent  []byte
 }
 
-type symmetricKeyParms struct {
+type symmetricKeyParams struct {
 	KeyLength uint32
 	BlockSize uint32
 	IV        []byte
@@ -216,7 +216,7 @@ type key struct {
 	KeyUsage       uint16
 	KeyFlags       uint32
 	AuthDataUsage  byte
-	AlgorithmParms keyParms
+	AlgorithmParams keyParams
 	PCRInfo        []byte
 	PubKey         []byte
 	EncData        []byte
@@ -229,7 +229,7 @@ type key12 struct {
 	KeyUsage       uint16
 	KeyFlags       uint32
 	AuthDataUsage  byte
-	AlgorithmParms keyParms
+	AlgorithmParams keyParams
 	PCRInfo        []byte // This must be a serialization of a pcrInfoLong.
 	PubKey         []byte
 	EncData        []byte
@@ -237,7 +237,7 @@ type key12 struct {
 
 // A pubKey represents a public key known to the TPM.
 type pubKey struct {
-	AlgorithmParms keyParms
+	AlgorithmParams keyParams
 	Key            []byte
 }
 
@@ -285,7 +285,7 @@ func convertPubKey(pk crypto.PublicKey) (*pubKey, error) {
 		return nil, errors.New("The provided Privacy CA RSA public key was not a 2048-bit key")
 	}
 
-	rsakp := rsaKeyParms{
+	rsakp := rsaKeyParams{
 		KeyLength: 2048,
 		NumPrimes: 2,
 		Exponent:  big.NewInt(int64(pkRSA.E)).Bytes(),
@@ -294,14 +294,14 @@ func convertPubKey(pk crypto.PublicKey) (*pubKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	kp := keyParms{
+	kp := keyParams{
 		AlgID:     algRSA,
 		EncScheme: esNone,
 		SigScheme: ssRSASaPKCS1v15SHA1,
-		Parms:     rsakpb,
+		Params:     rsakpb,
 	}
 	pubk := pubKey{
-		AlgorithmParms: kp,
+		AlgorithmParams: kp,
 		Key:            pkRSA.N.Bytes(),
 	}
 

--- a/tpm/structures.go
+++ b/tpm/structures.go
@@ -300,10 +300,10 @@ func convertPubKey(pk crypto.PublicKey) (*pubKey, error) {
 		SigScheme: ssRSASaPKCS1v15SHA1,
 		Params:     rsakpb,
 	}
-	pubk := pubKey{
+	pubKey := pubKey{
 		AlgorithmParams: kp,
 		Key:            pkRSA.N.Bytes(),
 	}
 
-	return &pubk, nil
+	return &pubKey, nil
 }

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -564,21 +564,21 @@ func MakeIdentity(rw io.ReadWriter, srkAuth []byte, ownerAuth []byte, aikAuth []
 		caDigest = sha1.Sum(caDigestBytes)
 	}
 
-	rsaAIKParms := rsaKeyParms{
+	rsaAIKParams := rsaKeyParams{
 		KeyLength: 2048,
 		NumPrimes: 2,
 		//Exponent:  big.NewInt(0x10001).Bytes(), // 65537. Implicit?
 	}
-	packedParms, err := tpmutil.Pack(rsaAIKParms)
+	packedParams, err := tpmutil.Pack(rsaAIKParams)
 	if err != nil {
 		return nil, err
 	}
 
-	aikParms := keyParms{
+	aikParams := keyParams{
 		AlgID:     algRSA,
 		EncScheme: esNone,
 		SigScheme: ssRSASaPKCS1v15SHA1,
-		Parms:     packedParms,
+		Params:     packedParams,
 	}
 
 	aik := &key{
@@ -586,7 +586,7 @@ func MakeIdentity(rw io.ReadWriter, srkAuth []byte, ownerAuth []byte, aikAuth []
 		KeyUsage:       keyIdentity,
 		KeyFlags:       0,
 		AuthDataUsage:  authAlways,
-		AlgorithmParms: aikParms,
+		AlgorithmParams: aikParams,
 	}
 
 	// The digest input for MakeIdentity authentication is
@@ -818,7 +818,7 @@ func TakeOwnership(rw io.ReadWriter, newOwnerAuth digest, newSRKAuth digest, pub
 	// - Sig must be None
 	// - Key usage must be Storage
 	// - Key must not be migratable
-	srkRSAParams := rsaKeyParms{
+	srkRSAParams := rsaKeyParams{
 		KeyLength: 2048,
 		NumPrimes: 2,
 	}
@@ -826,18 +826,18 @@ func TakeOwnership(rw io.ReadWriter, newOwnerAuth digest, newSRKAuth digest, pub
 	if err != nil {
 		return err
 	}
-	srkParams := keyParms{
+	srkParams := keyParams{
 		AlgID:     algRSA,
 		EncScheme: esRSAEsOAEPSHA1MGF1,
 		SigScheme: ssNone,
-		Parms:     srkpb,
+		Params:     srkpb,
 	}
 	srk := &key{
 		Version:        0x01010000,
 		KeyUsage:       keyStorage,
 		KeyFlags:       0,
 		AuthDataUsage:  authAlways,
-		AlgorithmParms: srkParams,
+		AlgorithmParams: srkParams,
 	}
 
 	// Get command auth using OIAP with the new owner auth.
@@ -899,7 +899,7 @@ func CreateWrapKey(rw io.ReadWriter, srkAuth []byte, usageAuth digest, migration
 		encMigrationAuth[i] = encAuthDataKey[i] ^ migrationAuth[i]
 	}
 
-	rParams := rsaKeyParms{
+	rParams := rsaKeyParams{
 		KeyLength: 2048,
 		NumPrimes: 2,
 	}
@@ -925,11 +925,11 @@ func CreateWrapKey(rw io.ReadWriter, srkAuth []byte, usageAuth digest, migration
 		KeyUsage:      keySigning,
 		KeyFlags:      0,
 		AuthDataUsage: authAlways,
-		AlgorithmParms: keyParms{
+		AlgorithmParams: keyParams{
 			AlgID:     algRSA,
 			EncScheme: esNone,
 			SigScheme: ssRSASaPKCS1v15DER,
-			Parms:     rParamsPacked,
+			Params:     rParamsPacked,
 		},
 		PCRInfo: pcrInfoBytes,
 	}

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -257,7 +257,7 @@ func newOSAPSession(rw io.ReadWriter, entityType uint16, entityValue tpmutil.Han
 	hm.Write(osapData)
 	// Note that crypto/hash.Sum returns a slice rather than an array, so we
 	// have to copy this into an array to make sure that serialization doesn't
-	// preprend a length in tpmutil.Pack().
+	// prepend a length in tpmutil.Pack().
 	sharedSecretBytes := hm.Sum(nil)
 	copy(sharedSecret[:], sharedSecretBytes)
 	return sharedSecret, osapr, nil

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -619,7 +619,7 @@ func MakeIdentity(rw io.ReadWriter, srkAuth []byte, ownerAuth []byte, aikAuth []
 		return nil, err
 	}
 
-	// TODO(tmroeder): check the signature against the pubek.
+	// TODO(tmroeder): check the signature against the pubEK.
 	blob, err := tpmutil.Pack(k)
 	if err != nil {
 		return nil, err

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -548,14 +548,14 @@ func MakeIdentity(rw io.ReadWriter, srkAuth []byte, ownerAuth []byte, aikAuth []
 	}
 
 	if pk != nil {
-		pubk, err := convertPubKey(pk)
+		pubKey, err := convertPubKey(pk)
 		if err != nil {
 			return nil, err
 		}
 
 		// We can't pack the pair of values directly, since the label is
 		// included directly as bytes, without any length.
-		fullpkb, err := tpmutil.Pack(pubk)
+		fullpkb, err := tpmutil.Pack(pubKey)
 		if err != nil {
 			return nil, err
 		}

--- a/tpm/tpm_test.go
+++ b/tpm/tpm_test.go
@@ -501,12 +501,12 @@ func TestTakeOwnership(t *testing.T) {
 	srkAuth := getAuth(srkAuthEnvVar)
 
 	// This test assumes that the TPM has been cleared using OwnerClear.
-	pubek, err := ReadPubEK(rwc)
+	pubEK, err := ReadPubEK(rwc)
 	if err != nil {
 		t.Fatal("Couldn't read the public endorsement key from the TPM:", err)
 	}
 
-	if err := TakeOwnership(rwc, ownerAuth, srkAuth, pubek); err != nil {
+	if err := TakeOwnership(rwc, ownerAuth, srkAuth, pubEK); err != nil {
 		t.Fatal("Couldn't take ownership of the TPM:", err)
 	}
 }

--- a/tpm/verify.go
+++ b/tpm/verify.go
@@ -43,14 +43,14 @@ func UnmarshalRSAPublicKey(keyBlob []byte) (*rsa.PublicKey, error) {
 // unmarshalRSAPublicKey unmarshals a TPM key into a crypto/rsa.PublicKey.
 func (k *key) unmarshalRSAPublicKey() (*rsa.PublicKey, error) {
 	// Currently, we only support algRSA
-	if k.AlgorithmParms.AlgID != algRSA {
+	if k.AlgorithmParams.AlgID != algRSA {
 		return nil, errors.New("only TPM_ALG_RSA is supported")
 	}
 
-	// This means that k.AlgorithmsParms.Parms is an rsaKeyParms, which is
+	// This means that k.AlgorithmsParams.Params is an rsaKeyParams, which is
 	// enough to create the exponent, and k.PubKey contains the key.
-	var rsakp rsaKeyParms
-	if _, err := tpmutil.Unpack(k.AlgorithmParms.Parms, &rsakp); err != nil {
+	var rsakp rsaKeyParams
+	if _, err := tpmutil.Unpack(k.AlgorithmParams.Params, &rsakp); err != nil {
 		return nil, err
 	}
 
@@ -82,14 +82,14 @@ func UnmarshalPubRSAPublicKey(keyBlob []byte) (*rsa.PublicKey, error) {
 // This is almost identical to the identically named function for a TPM key.
 func (pk *pubKey) unmarshalRSAPublicKey() (*rsa.PublicKey, error) {
 	// Currently, we only support algRSA
-	if pk.AlgorithmParms.AlgID != algRSA {
+	if pk.AlgorithmParams.AlgID != algRSA {
 		return nil, errors.New("only TPM_ALG_RSA is supported")
 	}
 
-	// This means that pk.AlgorithmsParms.Parms is an rsaKeyParms, which is
+	// This means that pk.AlgorithmsParams.Params is an rsaKeyParams, which is
 	// enough to create the exponent, and pk.Key contains the key.
-	var rsakp rsaKeyParms
-	if _, err := tpmutil.Unpack(pk.AlgorithmParms.Parms, &rsakp); err != nil {
+	var rsakp rsaKeyParams
+	if _, err := tpmutil.Unpack(pk.AlgorithmParams.Params, &rsakp); err != nil {
 		return nil, err
 	}
 

--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -157,7 +157,7 @@ const (
 // Capability identifies some TPM property or state type.
 type Capability uint32
 
-// TPM Capabilies.
+// TPM Capabilities.
 const (
 	CapabilityAlgs Capability = iota
 	CapabilityHandles

--- a/tpm2/kdf.go
+++ b/tpm2/kdf.go
@@ -50,7 +50,7 @@ func KDFa(hashAlg Algorithm, key []byte, label string, contextU, contextV []byte
 			return nil, fmt.Errorf("pack counter: %v", err)
 		}
 		mac.Write([]byte(label))
-		mac.Write([]byte{0}) // Terminating null chacter for C-string.
+		mac.Write([]byte{0}) // Terminating null character for C-string.
 		mac.Write(contextU)
 		mac.Write(contextV)
 		if err := binary.Write(mac, binary.BigEndian, uint32(bits)); err != nil {

--- a/tpmutil/mssim/mssim.go
+++ b/tpmutil/mssim/mssim.go
@@ -43,7 +43,7 @@ const (
 	tpmSessionEnd     uint32 = 20
 )
 
-// Config holds configuration parameters for connecting to the simluator.
+// Config holds configuration parameters for connecting to the simulator.
 type Config struct {
 	// Addresses of the command and platform handlers.
 	//
@@ -150,7 +150,7 @@ func (c *Conn) Read(b []byte) (int, error) {
 
 	var rc uint32
 	if err := binary.Read(c.conn, binary.BigEndian, &rc); err != nil {
-		return 0, fmt.Errorf("read MS simualtor return code: %v", err)
+		return 0, fmt.Errorf("read MS simulator return code: %v", err)
 	}
 	if rc != 0 {
 		return 0, fmt.Errorf("MS simulator returned invalid return code: 0x%x", rc)

--- a/tpmutil/mssim/mssim.go
+++ b/tpmutil/mssim/mssim.go
@@ -128,7 +128,7 @@ type Conn struct {
 }
 
 // Read a response from the simulator. If the response is longer than the provided
-// buffer, the remainer will be cached for the next read.
+// buffer, the remainder will be cached for the next read.
 func (c *Conn) Read(b []byte) (int, error) {
 	if c.prevRead != nil && c.prevRead.Len() > 0 {
 		return c.prevRead.Read(b)


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`