### PR TITLE
Named attributes for NV indexes and add NVReadPublic()

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -287,3 +287,32 @@ var hashConstructors = map[Algorithm]func() hash.Hash{
 	AlgSHA384: sha512.New384,
 	AlgSHA512: sha512.New,
 }
+
+// NVAttr is a bitmask used in Attributes field of NV indexes. Individual
+// flags should be OR-ed to form a full mask.
+type NVAttr uint32
+
+// NV Attributes
+const (
+	AttrPPWrite        NVAttr = 0x00000001
+	AttrOwnerWrite     NVAttr = 0x00000002
+	AttrAuthWrite      NVAttr = 0x00000004
+	AttrPolicyWrite    NVAttr = 0x00000008
+	AttrPolicyDelete   NVAttr = 0x00000400
+	AttrWriteLocked    NVAttr = 0x00000800
+	AttrWriteAll       NVAttr = 0x00001000
+	AttrWriteDefine    NVAttr = 0x00002000
+	AttrWriteSTClear   NVAttr = 0x00004000
+	AttrGlobalLock     NVAttr = 0x00008000
+	AttrPPRead         NVAttr = 0x00010000
+	AttrOwnerRead      NVAttr = 0x00020000
+	AttrAuthRead       NVAttr = 0x00040000
+	AttrPolicyRead     NVAttr = 0x00080000
+	AttrNoDA           NVAttr = 0x02000000
+	AttrOrderly        NVAttr = 0x04000000
+	AttrClearSTClear   NVAttr = 0x08000000
+	AttrReadLocked     NVAttr = 0x10000000
+	AttrWritten        NVAttr = 0x20000000
+	AttrPlatformCreate NVAttr = 0x40000000
+	AttrReadSTClear    NVAttr = 0x80000000
+)

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1076,7 +1076,7 @@ func decodeNVReadPublic(in []byte) (NVPublic, error) {
 	return pub, err
 }
 
-// NVReadPublic reads the public data of an NV index
+// NVReadPublic reads the public data of an NV index.
 func NVReadPublic(rw io.ReadWriter, index tpmutil.Handle) (NVPublic, error) {
 	// Read public area to determine data size.
 	resp, err := runCommand(rw, TagNoSessions, cmdReadPublicNV, index)

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -1014,16 +1014,16 @@ func TestNVReadWrite(t *testing.T) {
 		t.Fatalf("NVReadPublic failed: %v", err)
 	}
 	if int(pub.DataSize) != len(data) {
-		t.Fatalf("public NV data size doesn't match expected %d, got %d", pub.DataSize, len(data))
+		t.Fatalf("public NV data size mismatch, got %d, want %d, ", pub.DataSize, len(data))
 	}
 
 	// Read all of the data with NVReadEx and compare to what was written
 	outdata, err := NVReadEx(rw, idx, HandleOwner, emptyPassword, 0)
 	if err != nil {
-		t.Fatalf("NVRead failed: %v", err)
+		t.Fatalf("NVReadEx failed: %v", err)
 	}
 	if !bytes.Equal(data, outdata) {
-		t.Fatal("data read from NV index does not match expected")
+		t.Fatalf("data read from NV index does not match, got %x, want %x", outdata, data)
 	}
 }
 

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -979,14 +979,14 @@ func TestNVRead(t *testing.T) {
 	}
 }
 
-func TestNVWrite(t *testing.T) {
+func TestNVReadWrite(t *testing.T) {
 	rw := openTPM(t)
 	defer rw.Close()
 
 	var (
 		idx  tpmutil.Handle = 0x1500000
 		data                = []byte("testdata")
-		attr uint32         = 0x20002 // TODO: change to named attributes like NVAttrOwnerWrite|NVAttrOwnerRead
+		attr                = AttrOwnerWrite | AttrOwnerRead
 	)
 
 	// Define space in NV storage and clean up afterwards or subsequent runs will fail.
@@ -1006,6 +1006,24 @@ func TestNVWrite(t *testing.T) {
 	// Write the data
 	if err := NVWrite(rw, HandleOwner, idx, emptyPassword, data, 0); err != nil {
 		t.Fatalf("NVWrite failed: %v", err)
+	}
+
+	// Make sure the public area of the index can be read
+	pub, err := NVReadPublic(rw, idx)
+	if err != nil {
+		t.Fatalf("NVReadPublic failed: %v", err)
+	}
+	if int(pub.DataSize) != len(data) {
+		t.Fatalf("public NV data size doesn't match expected %d, got %d", pub.DataSize, len(data))
+	}
+
+	// Read all of the data with NVReadEx and compare to what was written
+	outdata, err := NVReadEx(rw, idx, HandleOwner, emptyPassword, 0)
+	if err != nil {
+		t.Fatalf("NVRead failed: %v", err)
+	}
+	if !bytes.Equal(data, outdata) {
+		t.Fatal("data read from NV index does not match expected")
 	}
 }
 


### PR DESCRIPTION
Supercedes https://github.com/google/go-tpm/pull/54

- Adds named attributes for NV indexes in NVDefineSpace()
- Exposes NVReadPublic()
- Expands NV read and write test 