### PR TITLE
Initialize go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/google/go-tpm


### PR DESCRIPTION
This makes go-tpm a Go module.
After this PR is submitted, I'll tag v0.0.1 on master.
After that, we can start submitting incompatible changes and tagging
them as v0.(N+1).0.

Fixes #58 