### PR TITLE
Add Handle Type constants and some max capabilities constants.

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -80,6 +80,22 @@ const (
 	AlgECB       Algorithm = 0x0044
 )
 
+// HandleType defines a type of handle.
+type HandleType uint8
+
+// Supported handle types
+const (
+	HandleTypePCR           HandleType = 0x00
+	HandleTypeNVIndex       HandleType = 0x01
+	HandleTypeHMACSession   HandleType = 0x02
+	HandleTypeLoadedSession HandleType = 0x02
+	HandleTypePolicySession HandleType = 0x03
+	HandleTypeSavedSession  HandleType = 0x03
+	HandleTypePermanent     HandleType = 0x40
+	HandleTypeTransient     HandleType = 0x80
+	HandleTypePersistent    HandleType = 0x81
+)
+
 // SessionType defines the type of session created in StartAuthSession.
 type SessionType uint8
 
@@ -169,6 +185,13 @@ const (
 	CapabilityPCRProperties
 	CapabilityECCCurves
 	CapabilityAuthPolicies
+)
+
+// Maximum valous for capabilities
+const (
+	MaxCapabilityBufferLength uint32 = 1024
+	MaxCapabilityData         uint32 = MaxCapabilityBufferLength - 4 - 4
+	MaxCapabilityHandles      uint32 = MaxCapabilityData / 4
 )
 
 // TPM Structure Tags. Tags are used to disambiguate structures, similar to Alg

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -132,7 +132,7 @@ func TestGetCapability(t *testing.T) {
 		property uint32
 		typ      interface{}
 	}{
-		{CapabilityHandles, 1, 0x80000000, tpmutil.Handle(0)},
+		{CapabilityHandles, 1, uint32(HandleTypeTransient) << 24, tpmutil.Handle(0)},
 		{CapabilityAlgs, 1, 0, AlgorithmDescription{}},
 		{CapabilityTPMProperties, 1, uint32(NVMaxBufferSize), TaggedProperty{}},
 	} {


### PR DESCRIPTION
Added all constants for the Handle Type (TPM_HT, Section 7.2 of [part 2 of the spec](https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-2-Structures-01.38.pdf)).

Added some constants yielding MaxCapabilityHandles (Section 5.5 of [part 4 of the spec](https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-4-Supporting-Routines-01.38-code.pdf)).

Needed for WIP tooling around handles within google/go-tpm-tools.