### PR TITLE
Add public command code for PolicyPCR

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -271,11 +271,13 @@ const (
 	cmdGetRandom        tpmutil.Command = 0x0000017B
 	cmdHash             tpmutil.Command = 0x0000017D
 	cmdPCRRead          tpmutil.Command = 0x0000017E
-	cmdPolicyPCR        tpmutil.Command = 0x0000017F
-	cmdReadClock        tpmutil.Command = 0x00000181
-	cmdPCRExtend        tpmutil.Command = 0x00000182
-	cmdPolicyGetDigest  tpmutil.Command = 0x00000189
-	cmdPolicyPassword   tpmutil.Command = 0x0000018C
+	// CmdPolicyPCR is the command code for TPM2_PolicyPCR.
+	// It's exported for computing AuthPolicy values for PCR-based sessions.
+	CmdPolicyPCR       tpmutil.Command = 0x0000017F
+	cmdReadClock       tpmutil.Command = 0x00000181
+	cmdPCRExtend       tpmutil.Command = 0x00000182
+	cmdPolicyGetDigest tpmutil.Command = 0x00000189
+	cmdPolicyPassword  tpmutil.Command = 0x0000018C
 )
 
 // Regular TPM 2.0 devices use 24-bit mask (3 bytes) for PCR selection.

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -692,7 +692,7 @@ func PolicyPCR(rw io.ReadWriter, session tpmutil.Handle, expectedDigest []byte, 
 	if err != nil {
 		return err
 	}
-	_, err = runCommand(rw, TagNoSessions, cmdPolicyPCR, tpmutil.RawBytes(cmd))
+	_, err = runCommand(rw, TagNoSessions, CmdPolicyPCR, tpmutil.RawBytes(cmd))
 	return err
 }
 


### PR DESCRIPTION
This value needs to be exposed for computing AuthPolicy values.
Specificallly, we will need it for predictive Sealing. See:
    https://github.com/google/go-tpm-tools/pull/10