### PR TITLE
Make flags consistent

### DIFF
--- a/examples/tpm-sign/generate.go
+++ b/examples/tpm-sign/generate.go
@@ -30,7 +30,7 @@ import (
 func generateAction() {
 	var tpmname = flag.String("tpm", "/dev/tpm0", "The path to the TPM device to use")
 	var keyblobPath = flag.String("keyblob", "keyblob", "Output path of the generated keyblob")
-	var pubKeyPath = flag.String("publicKey", "publickey", "Output path of the generated keyblob's public key")
+	var pubKeyPath = flag.String("public-key", "publickey", "Output path of the generated keyblob's public key")
 	var pcrsStr = flag.String("pcrs", "", "A comma-separated list of PCR numbers against which the generated key will be bound. If blank, it will not be bound to any PCR values.")
 	flag.CommandLine.Parse(os.Args[2:])
 

--- a/examples/tpm-sign/verify.go
+++ b/examples/tpm-sign/verify.go
@@ -24,7 +24,7 @@ import (
 )
 
 func verifyAction() {
-	var pubKeyPath = flag.String("publicKey", "publickey", "Input path of public key file")
+	var pubKeyPath = flag.String("public-key", "publickey", "Input path of public key file")
 	var hashAlgArg = flag.String("hash", "SHA256", "Hash algorithm to use when verifying the signature")
 	var signaturePath = flag.String("signature", "sig.data", "Input path of previously generated signature")
 	var dataPath = flag.String("data", "", "Path to the data that was signed. If empty or omitted, the data will be read from stdin.")

--- a/tpm2/README.md
+++ b/tpm2/README.md
@@ -9,7 +9,7 @@ By default, running `go test` will skip them. To run the tests on a host with
 available TPM device, run
 
 ```
-go test --tpm_path=/dev/tpm0
+go test --tpm-path=/dev/tpm0
 ```
 
 where `/dev/tpm0` is path to a TPM character device or a Unix socket.

--- a/tpm2/tpm2_linux_test.go
+++ b/tpm2/tpm2_linux_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-var tpmPath = flag.String("tpm_path", "", "Path to TPM character device. Most Linux systems expose it under /dev/tpm0. Empty value (default) will disable all integration tests.")
+var tpmPath = flag.String("tpm-path", "", "Path to TPM character device. Most Linux systems expose it under /dev/tpm0. Empty value (default) will disable all integration tests.")
 
 func openDeviceTPM(t testing.TB) io.ReadWriteCloser {
 	if *tpmPath == "" {

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -38,8 +38,8 @@ import (
 
 var (
 	mssimRun          = flag.Bool("mssim", false, "If supplied, run integration tests against a Microsoft simulator.")
-	mssimCommandAddr  = flag.String("mssim_command_addr", "localhost:2321", "Host and port of the simulator's command listener")
-	mssimPlatformAddr = flag.String("mssim_platform_addr", "localhost:2322", "Host and port of the simulator's platform listener")
+	mssimCommandAddr  = flag.String("mssim-command-addr", "localhost:2321", "Host and port of the simulator's command listener")
+	mssimPlatformAddr = flag.String("mssim-platform-addr", "localhost:2322", "Host and port of the simulator's platform listener")
 )
 
 func openTPM(t testing.TB) io.ReadWriteCloser {

--- a/tpm2/tpm2_windows_test.go
+++ b/tpm2/tpm2_windows_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-var runTPMTests = flag.Bool("run_tpm_tests", false, "Run the Windows TPM integration tests. Defaults to false.")
+var runTPMTests = flag.Bool("use-tbs", false, "Run integration tests against Windows TPM Base Services (TBS). Defaults to false.")
 
 func openDeviceTPM(t *testing.T) io.ReadWriteCloser {
 	if *runTPMTests == false {


### PR DESCRIPTION
In go-tpm, some of our flags use dashes (in `examples`) and some use
underscores (in `tpm2` testing code). This change makes it so all flags
will use dashes. This ensures that all example binaries still take the
same arguments.

The windows flag name is also changed to make it clear what it is actually doing.