### PR TITLE
Remove unnecessary TestMain

### DIFF
--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -59,11 +58,6 @@ func openTPM(t testing.TB) io.ReadWriteCloser {
 		t.Fatalf("Startup TPM failed: %v", err)
 	}
 	return conn
-}
-
-func TestMain(m *testing.M) {
-	flag.Parse()
-	os.Exit(m.Run())
 }
 
 var (


### PR DESCRIPTION
The TestMain in tpm2_test.go is not needed. Flags will be parsed by the
default TestMain.