### PR TITLE
Add method to get a crypto.PublicKey key from tpm2.Public

### DIFF
--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -16,6 +16,9 @@ package tpm2
 
 import (
 	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
 	"errors"
 	"fmt"
 	"math/big"
@@ -88,6 +91,30 @@ func (p Public) Encode() ([]byte, error) {
 		return nil, fmt.Errorf("encoding RSAParameters, ECCParameters or KeyedHash: %v", err)
 	}
 	return concat(head, params)
+}
+
+// Key returns the (public) key from the public area of an object.
+func (p Public) Key() (crypto.PublicKey, error) {
+	var pubKey crypto.PublicKey
+	switch p.Type {
+	case AlgRSA:
+		// Endianness of big.Int.Bytes/SetBytes and modulus in the TPM is the same
+		// (big-endian).
+		pubKey = &rsa.PublicKey{N: p.RSAParameters.Modulus, E: int(p.RSAParameters.Exponent)}
+	case AlgECC:
+		curve, ok := toGoCurve[p.ECCParameters.CurveID]
+		if !ok {
+			return nil, fmt.Errorf("can't map TPM EC curve ID 0x%x to Go elliptic.Curve value", p.ECCParameters.CurveID)
+		}
+		pubKey = &ecdsa.PublicKey{
+			X:     p.ECCParameters.Point.X,
+			Y:     p.ECCParameters.Point.Y,
+			Curve: curve,
+		}
+	default:
+		return nil, fmt.Errorf("unsupported primary key type 0x%x", p.Type)
+	}
+	return pubKey, nil
 }
 
 // DecodePublic decodes a TPMT_PUBLIC message. No error is returned if

--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -112,7 +112,7 @@ func (p Public) Key() (crypto.PublicKey, error) {
 			Curve: curve,
 		}
 	default:
-		return nil, fmt.Errorf("unsupported primary key type 0x%x", p.Type)
+		return nil, fmt.Errorf("unsupported public key type 0x%x", p.Type)
 	}
 	return pubKey, nil
 }

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -1084,3 +1084,28 @@ func TestQuote(t *testing.T) {
 		t.Errorf("VerifyPKCS1v15 failed: %v", err)
 	}
 }
+
+func TestReadPublicKey(t *testing.T) {
+	rw := openTPM(t)
+	defer rw.Close()
+
+	keyHandle, pubKey1, err := CreatePrimary(rw, HandleOwner, pcrSelection, emptyPassword, defaultPassword, defaultKeyParams)
+	if err != nil {
+		t.Fatalf("CreatePrimary failed: %s", err)
+	}
+	defer FlushContext(rw, keyHandle)
+
+	pub, _, _, err := ReadPublic(rw, keyHandle)
+	if err != nil {
+		t.Fatalf("ReadPublic failed: %s", err)
+	}
+
+	pubKey2, err := pub.Key()
+	if err != nil {
+		t.Fatalf("Public.Key() failed: %s", err)
+	}
+
+	if !reflect.DeepEqual(pubKey1, pubKey2) {
+		t.Fatalf("Public.Key() = %#v; want %#v", pubKey2, pubKey1)
+	}
+}


### PR DESCRIPTION
This change moves the code that extract the public key from tpm2.Public so it can be used to more generally. The reason is that `CreatePrimary()` already returns a crypto.PublicKey, while `ReadPublic()` does not.