### PR TITLE
Support building on darwin and other OS

### DIFF
--- a/tpmutil/run_other.go
+++ b/tpmutil/run_other.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 // Copyright (c) 2018, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This PR enables building on darwin and other OS. There are no syscalls or other low-level operations in here and only Windows appears be needing a different file.