### PR TITLE
Call Shutdown() on simulator connection on close to avoid lockout

### DIFF
--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -57,7 +57,24 @@ func openTPM(t testing.TB) io.ReadWriteCloser {
 		conn.Close()
 		t.Fatalf("Startup TPM failed: %v", err)
 	}
-	return conn
+	return Simulator{conn}
+}
+
+// Simulator is a wrapper around a simulator connection that ensures shutdown is called on close.
+// This is only necessary with simulators. If shutdown isn't called before disconnecting, the
+// lockout counter in the simulator is incremented leading to DA lockout after running a few tests.
+type Simulator struct {
+	*mssim.Conn
+}
+
+// Close calls Shutdown() on the simulator before disconnecting to ensure the lockout counter doesn't
+// get incremented.
+func (s Simulator) Close() error {
+	if err := Shutdown(s, StartupClear); err != nil {
+		s.Conn.Close()
+		return err
+	}
+	return s.Conn.Close()
 }
 
 var (

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -57,19 +57,19 @@ func openTPM(t testing.TB) io.ReadWriteCloser {
 		conn.Close()
 		t.Fatalf("Startup TPM failed: %v", err)
 	}
-	return Simulator{conn}
+	return simulator{conn}
 }
 
 // Simulator is a wrapper around a simulator connection that ensures shutdown is called on close.
 // This is only necessary with simulators. If shutdown isn't called before disconnecting, the
 // lockout counter in the simulator is incremented leading to DA lockout after running a few tests.
-type Simulator struct {
+type simulator struct {
 	*mssim.Conn
 }
 
 // Close calls Shutdown() on the simulator before disconnecting to ensure the lockout counter doesn't
 // get incremented.
-func (s Simulator) Close() error {
+func (s simulator) Close() error {
 	if err := Shutdown(s, StartupClear); err != nil {
 		s.Conn.Close()
 		return err


### PR DESCRIPTION
The simulator is going into DA lockout currently when running tests 3 times. That's due to it incrementing the lockout counter on Close without Shutdown first. This change ensures that Shutdown is called, preventing frequent lockouts. Lockout is definitely happening with the IBM simulator, haven't tried the MS one but it should behave similarly.