### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/tpmutil/run_windows.go
+++ b/tpmutil/run_windows.go
@@ -26,7 +26,7 @@ type winTPMBuffer struct {
 	outBuffer []byte
 }
 
-// Executes the TPM command specified by commandBuffer (at Normal Priority), returning the number
+// Write executes the TPM command specified by commandBuffer (at Normal Priority), returning the number
 // of bytes in the command and any error code returned by executing the TPM command. Command
 // response can be read by calling Read().
 func (rwc *winTPMBuffer) Write(commandBuffer []byte) (int, error) {


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?