### PR TITLE
Added ActivateIdentity

### DIFF
--- a/tpm/commands.go
+++ b/tpm/commands.go
@@ -210,6 +210,22 @@ func makeIdentity(rw io.ReadWriter, encAuth digest, idDigest digest, k *key, ca1
 	return &aik, sig, &ra1, &ra2, ret, nil
 }
 
+// activateIdentity provides the TPM with an EK encrypted challenge and asks it to
+// decrypt the challenge and return the secret (symmetric key).
+func activateIdentity(rw io.ReadWriter, keyHandle tpmutil.Handle, blob []byte, ca1 *commandAuth, ca2 *commandAuth) (*symKey, *responseAuth, *responseAuth, uint32, error) {
+	in := []interface{}{keyHandle, blob, ca1, ca2}
+	var symkey symKey
+	var ra1 responseAuth
+	var ra2 responseAuth
+	out := []interface{}{&symkey, &ra1, &ra2}
+	ret, err := submitTPMRequest(rw, tagRQUAuth2Command, ordActivateIdentity, in, out)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+
+	return &symkey, &ra1, &ra2, ret, nil
+}
+
 // resetLockValue resets the dictionary-attack lock in the TPM, using owner
 // auth.
 func resetLockValue(rw io.ReadWriter, ca *commandAuth) (*responseAuth, uint32, error) {

--- a/tpm/constants.go
+++ b/tpm/constants.go
@@ -53,6 +53,7 @@ const (
 	ordForceClear           uint32 = 0x0000005D
 	ordGetCapability        uint32 = 0x00000065
 	ordMakeIdentity         uint32 = 0x00000079
+	ordActivateIdentity     uint32 = 0x0000007A
 	ordReadPubEK            uint32 = 0x0000007C
 	ordOwnerReadInternalPub uint32 = 0x00000081
 	ordFlushSpecific        uint32 = 0x000000BA
@@ -130,6 +131,7 @@ const (
 	esRSAEsOAEPSHA1MGF1
 	esSymCTR
 	esSymOFB
+	esSymCBCPKCS5 = 0xff // esSymCBCPKCS5 was taken from go-tspi
 )
 
 // Signature schemes. These are only valid under algRSA.

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -18,12 +18,15 @@ package tpm
 import (
 	"bytes"
 	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/google/go-tpm/tpmutil"
@@ -626,6 +629,124 @@ func MakeIdentity(rw io.ReadWriter, srkAuth []byte, ownerAuth []byte, aikAuth []
 	}
 
 	return blob, nil
+}
+
+func unloadTrspiCred(blob []byte) ([]byte, error) {
+	/*
+	 * Trousers expects the asym blob to have an additional data in the header.
+	 * The relevant data is duplicated in the TPM_SYMMETRIC_KEY struct so we parse
+	 * and throw the header away.
+	 * TODO(dkarch): Trousers is not doing credential activation correctly. We should
+	 * remove this and instead expose the asymmetric decryption and symmetric decryption
+	 * so that anyone generating a challenge for Trousers can unload the header themselves
+	 * and send us a correctly formatted challenge.
+	 */
+
+	var header struct {
+		Credsize  uint32
+		AlgID     uint32
+		EncScheme uint16
+		SigScheme uint16
+		Parmsize  uint32
+	}
+
+	symbuf := bytes.NewReader(blob)
+	if err := binary.Read(symbuf, binary.BigEndian, &header); err != nil {
+		return nil, err
+	}
+	// Unload the symmetric key parameters.
+	parms := make([]byte, header.Parmsize)
+	if err := binary.Read(symbuf, binary.BigEndian, parms); err != nil {
+		return nil, err
+	}
+	// Unload and return the symmetrically encrypted secret.
+	cred := make([]byte, header.Credsize)
+	if err := binary.Read(symbuf, binary.BigEndian, cred); err != nil {
+		return nil, err
+	}
+	return cred, nil
+}
+
+// ActivateIdentity asks the TPM to decrypt an EKPub encrypted symmetric session key
+// which it uses to decrypt the symmetrically encrypted secret.
+func ActivateIdentity(rw io.ReadWriter, aikAuth []byte, ownerAuth []byte, aik tpmutil.Handle, asym, sym []byte) ([]byte, error) {
+	// Run OIAP for the AIK.
+	oiaprAIK, err := oiap(rw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start OIAP session: %v", err)
+	}
+
+	// Run OSAP for the owner, reading a random OddOSAP for our initial command
+	// and getting back a secret and a handle.
+	sharedSecretOwn, osaprOwn, err := newOSAPSession(rw, etOwner, khOwner, ownerAuth)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start OSAP session: %v", err)
+	}
+	defer osaprOwn.Close(rw)
+	defer zeroBytes(sharedSecretOwn[:])
+
+	authIn := []interface{}{ordActivateIdentity, asym}
+	ca1, err := newCommandAuth(oiaprAIK.AuthHandle, oiaprAIK.NonceEven, aikAuth, authIn)
+	if err != nil {
+		return nil, fmt.Errorf("newCommandAuth failed: %v", err)
+	}
+	ca2, err := newCommandAuth(osaprOwn.AuthHandle, osaprOwn.NonceEven, sharedSecretOwn[:], authIn)
+	if err != nil {
+		return nil, fmt.Errorf("newCommandAuth failed: %v", err)
+	}
+
+	symkey, ra1, ra2, ret, err := activateIdentity(rw, aik, asym, ca1, ca2)
+	if err != nil {
+		return nil, fmt.Errorf("activateIdentity failed: %v", err)
+	}
+
+	// Check response authentication.
+	raIn := []interface{}{ret, ordActivateIdentity, symkey}
+	if err := ra1.verify(ca1.NonceOdd, aikAuth, raIn); err != nil {
+		return nil, fmt.Errorf("aik resAuth failed to verify: %v", err)
+	}
+
+	if err := ra2.verify(ca2.NonceOdd, sharedSecretOwn[:], raIn); err != nil {
+		return nil, fmt.Errorf("owner resAuth failed to verify: %v", err)
+	}
+
+	cred, err := unloadTrspiCred(sym)
+	var (
+		block     cipher.Block
+		iv        []byte
+		ciphertxt []byte
+		secret    []byte
+	)
+	switch id := symkey.AlgID; id {
+	case algAES128:
+		block, err = aes.NewCipher(symkey.Key)
+		if err != nil {
+			return nil, fmt.Errorf("aes.NewCipher failed: %v", err)
+		}
+		iv = cred[:aes.BlockSize]
+		ciphertxt = cred[aes.BlockSize:]
+		secret = ciphertxt
+	default:
+		return nil, fmt.Errorf("%v is not a supported session key algorithm", id)
+	}
+	switch es := symkey.EncScheme; es {
+	case esSymCTR:
+		stream := cipher.NewCTR(block, iv)
+		stream.XORKeyStream(secret, ciphertxt)
+	case esSymOFB:
+		stream := cipher.NewOFB(block, iv)
+		stream.XORKeyStream(secret, ciphertxt)
+	case esSymCBCPKCS5:
+		mode := cipher.NewCBCDecrypter(block, iv)
+		mode.CryptBlocks(secret, ciphertxt)
+		// Remove PKCS5 padding.
+		padlen := int(secret[len(secret)-1])
+		secret = secret[:len(secret)-padlen]
+	default:
+		return nil, fmt.Errorf("%v is not a supported encryption scheme", es)
+	}
+
+	return secret, nil
 }
 
 // ResetLockValue resets the dictionary-attack value in the TPM; this allows the

--- a/tpmutil/structures.go
+++ b/tpmutil/structures.go
@@ -14,6 +14,8 @@
 
 package tpmutil
 
+import "io"
+
 // RawBytes is for Pack and RunCommand arguments that are already encoded.
 // Compared to []byte, RawBytes will not be prepended with slice length during
 // encoding.
@@ -48,3 +50,11 @@ type responseHeader struct {
 
 // A Handle is a reference to a TPM object.
 type Handle uint32
+
+// SelfMarshaler allows custom types to override default encoding/decoding
+// behavior in Pack, Unpack and UnpackBuf.
+type SelfMarshaler interface {
+	TPMMarshal(out io.Writer) error
+	TPMUnmarshal(in io.Reader) error
+	TPMPackedSize() int
+}


### PR DESCRIPTION
Adding ActivateIdentity required modifying tpmutil\encoding.go in order
to properly parse TPM_SYMMETRIC_KEY which has a slice whose length is a
uint16 (as opposed to uint32 as with most other TPM1.2 structs)