### PR TITLE
Add NVReadValue and ReadEKCert

### DIFF
--- a/tpm/commands.go
+++ b/tpm/commands.go
@@ -143,6 +143,18 @@ func getPubKey(rw io.ReadWriter, keyHandle tpmutil.Handle, ca *commandAuth) (*pu
 	return &pk, &ra, ret, nil
 }
 
+func nvReadValue(rw io.ReadWriter, index, offset, len uint32, ca *commandAuth) ([]byte, *responseAuth, uint32, error) {
+	var b []byte
+	var ra responseAuth
+	in := []interface{}{index, offset, len, ca}
+	out := []interface{}{&b, &ra}
+	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordNVReadValue, in, out)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	return b, &ra, ret, nil
+}
+
 // quote2 signs arbitrary data under a given set of PCRs and using a key
 // specified by keyHandle. It returns information about the PCRs it signed
 // under, the signature, auth information, and optionally information about the

--- a/tpm/constants.go
+++ b/tpm/constants.go
@@ -57,6 +57,7 @@ const (
 	ordOwnerReadInternalPub uint32 = 0x00000081
 	ordFlushSpecific        uint32 = 0x000000BA
 	ordPcrReset             uint32 = 0x000000C8
+	ordNVReadValue          uint32 = 0x000000CF
 )
 
 // Capability types.

--- a/tpm/tpm_test.go
+++ b/tpm/tpm_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/sha1"
+	"crypto/x509"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -81,6 +82,24 @@ func TestPcrExtend(t *testing.T) {
 		t.Logf("PCR are equal!\n")
 	} else {
 		t.Fatal("PCR are not equal! Test failed.\n")
+	}
+}
+
+func TestReadEKCert(t *testing.T) {
+	rwc := openTPMOrSkip(t)
+	defer rwc.Close()
+
+	ownAuth := getAuth(ownerAuthEnvVar)
+	cert, err := ReadEKCert(rwc, ownAuth)
+	if err != nil {
+		t.Fatal("Unable to read EKCert from NVRAM:", err)
+	}
+
+	x509cert, err := x509.ParseCertificate(cert)
+	if err != nil {
+		t.Logf("Malformed certificate: %v\n", err)
+	} else {
+		t.Logf("Certificate: %v\n", x509cert)
 	}
 }
 


### PR DESCRIPTION
NVReadValue consumes a location and a length and tries to read length
bytes from the requested location in NVRAM.

ReadEKCert reads the EKCert at the default location in NVRAM.