### PR TITLE
Make DecodeSignature public

### DIFF
--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -454,7 +454,8 @@ type Signature struct {
 	ECC *SignatureECC
 }
 
-func decodeSignature(in *bytes.Buffer) (*Signature, error) {
+// DecodeSignature decodes a serialized TPMT_SIGNATURE structure.
+func DecodeSignature(in *bytes.Buffer) (*Signature, error) {
 	var sig Signature
 	if err := tpmutil.UnpackBuf(in, &sig.Alg); err != nil {
 		return nil, fmt.Errorf("decoding Alg: %v", err)

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -793,7 +793,7 @@ func decodeQuote(in []byte) ([]byte, *Signature, error) {
 	if err := tpmutil.UnpackBuf(buf, &paramSize, &attest); err != nil {
 		return nil, nil, err
 	}
-	sig, err := decodeSignature(buf)
+	sig, err := DecodeSignature(buf)
 	return attest, sig, err
 }
 
@@ -1214,7 +1214,7 @@ func decodeSign(buf []byte) (*Signature, error) {
 	if err := tpmutil.UnpackBuf(in, &paramSize); err != nil {
 		return nil, err
 	}
-	return decodeSignature(in)
+	return DecodeSignature(in)
 }
 
 // Sign computes a signature for digest using a given loaded key. Signature


### PR DESCRIPTION
DecodeAttestationData is already public. If a user wants to verify it
outside of a TPM they need to decode the TPMT_SIGNATURE structure too.