### PR TITLE
Replace global prefix size with U32Bytes and U16Bytes

### DIFF
--- a/tpm/commands.go
+++ b/tpm/commands.go
@@ -67,7 +67,7 @@ func osap(rw io.ReadWriter, osap *osapCommand) (*osapResponse, error) {
 }
 
 // seal performs a seal operation on the TPM.
-func seal(rw io.ReadWriter, sc *sealCommand, pcrs *pcrInfoLong, data []byte, ca *commandAuth) (*tpmStoredData, *responseAuth, uint32, error) {
+func seal(rw io.ReadWriter, sc *sealCommand, pcrs *pcrInfoLong, data tpmutil.U32Bytes, ca *commandAuth) (*tpmStoredData, *responseAuth, uint32, error) {
 	pcrsize := binary.Size(pcrs)
 	if pcrsize < 0 {
 		return nil, nil, 0, errors.New("couldn't compute the size of a pcrInfoLong")
@@ -91,7 +91,7 @@ func seal(rw io.ReadWriter, sc *sealCommand, pcrs *pcrInfoLong, data []byte, ca 
 // unseal data sealed by the TPM.
 func unseal(rw io.ReadWriter, keyHandle tpmutil.Handle, sealed *tpmStoredData, ca1 *commandAuth, ca2 *commandAuth) ([]byte, *responseAuth, *responseAuth, uint32, error) {
 	in := []interface{}{keyHandle, sealed, ca1, ca2}
-	var outb []byte
+	var outb tpmutil.U32Bytes
 	var ra1 responseAuth
 	var ra2 responseAuth
 	out := []interface{}{&outb, &ra1, &ra2}
@@ -149,8 +149,8 @@ func getCapability(rw io.ReadWriter, cap, subcap uint32) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var b []byte
-	in := []interface{}{cap, subCapBytes}
+	var b tpmutil.U32Bytes
+	in := []interface{}{cap, tpmutil.U32Bytes(subCapBytes)}
 	out := []interface{}{&b}
 	if _, err := submitTPMRequest(rw, tagRQUCommand, ordGetCapability, in, out); err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func getCapability(rw io.ReadWriter, cap, subcap uint32) ([]byte, error) {
 }
 
 func nvReadValue(rw io.ReadWriter, index, offset, len uint32, ca *commandAuth) ([]byte, *responseAuth, uint32, error) {
-	var b []byte
+	var b tpmutil.U32Bytes
 	var ra responseAuth
 	in := []interface{}{index, offset, len, ca}
 	out := []interface{}{&b, &ra}
@@ -179,8 +179,8 @@ func quote2(rw io.ReadWriter, keyHandle tpmutil.Handle, hash [20]byte, pcrs *pcr
 	in := []interface{}{keyHandle, hash, pcrs, addVersion, ca}
 	var pcrShort pcrInfoShort
 	var capInfo capVersionInfo
-	var capBytes []byte
-	var sig []byte
+	var capBytes tpmutil.U32Bytes
+	var sig tpmutil.U32Bytes
 	var ra responseAuth
 	out := []interface{}{&pcrShort, &capBytes, &sig, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordQuote2, in, out)
@@ -189,17 +189,17 @@ func quote2(rw io.ReadWriter, keyHandle tpmutil.Handle, hash [20]byte, pcrs *pcr
 	}
 
 	// Deserialize the capInfo, if any.
-	if len(capBytes) == 0 {
+	if len([]byte(capBytes)) == 0 {
 		return &pcrShort, nil, capBytes, sig, &ra, ret, nil
 	}
 
 	size := binary.Size(capInfo.CapVersionFixed)
-	capInfo.VendorSpecific = make([]byte, len(capBytes)-size)
-	if _, err := tpmutil.Unpack(capBytes[:size], &capInfo.CapVersionFixed); err != nil {
+	capInfo.VendorSpecific = make([]byte, len([]byte(capBytes))-size)
+	if _, err := tpmutil.Unpack([]byte(capBytes)[:size], &capInfo.CapVersionFixed); err != nil {
 		return nil, nil, nil, nil, nil, 0, err
 	}
 
-	copy(capInfo.VendorSpecific, capBytes[size:])
+	copy(capInfo.VendorSpecific, []byte(capBytes)[size:])
 
 	return &pcrShort, &capInfo, capBytes, sig, &ra, ret, nil
 }
@@ -209,7 +209,7 @@ func quote2(rw io.ReadWriter, keyHandle tpmutil.Handle, hash [20]byte, pcrs *pcr
 func quote(rw io.ReadWriter, keyHandle tpmutil.Handle, hash [20]byte, pcrs *pcrSelection, ca *commandAuth) (*pcrComposite, []byte, *responseAuth, uint32, error) {
 	in := []interface{}{keyHandle, hash, pcrs, ca}
 	var pcrc pcrComposite
-	var sig []byte
+	var sig tpmutil.U32Bytes
 	var ra responseAuth
 	out := []interface{}{&pcrc, &sig, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordQuote, in, out)
@@ -225,7 +225,7 @@ func quote(rw io.ReadWriter, keyHandle tpmutil.Handle, hash [20]byte, pcrs *pcrS
 func makeIdentity(rw io.ReadWriter, encAuth digest, idDigest digest, k *key, ca1 *commandAuth, ca2 *commandAuth) (*key, []byte, *responseAuth, *responseAuth, uint32, error) {
 	in := []interface{}{encAuth, idDigest, k, ca1, ca2}
 	var aik key
-	var sig []byte
+	var sig tpmutil.U32Bytes
 	var ra1 responseAuth
 	var ra2 responseAuth
 	out := []interface{}{&aik, &sig, &ra1, &ra2}
@@ -239,7 +239,7 @@ func makeIdentity(rw io.ReadWriter, encAuth digest, idDigest digest, k *key, ca1
 
 // activateIdentity provides the TPM with an EK encrypted challenge and asks it to
 // decrypt the challenge and return the secret (symmetric key).
-func activateIdentity(rw io.ReadWriter, keyHandle tpmutil.Handle, blob []byte, ca1 *commandAuth, ca2 *commandAuth) (*symKey, *responseAuth, *responseAuth, uint32, error) {
+func activateIdentity(rw io.ReadWriter, keyHandle tpmutil.Handle, blob tpmutil.U32Bytes, ca1 *commandAuth, ca2 *commandAuth) (*symKey, *responseAuth, *responseAuth, uint32, error) {
 	in := []interface{}{keyHandle, blob, ca1, ca2}
 	var symkey symKey
 	var ra1 responseAuth
@@ -317,7 +317,7 @@ func ownerClear(rw io.ReadWriter, ca *commandAuth) (*responseAuth, uint32, error
 // owner auth. This operation can only be performed if there is no owner. The
 // TPM can be put into this state using TPM_OwnerClear. The encOwnerAuth and
 // encSRKAuth values must be encrypted using the endorsement key.
-func takeOwnership(rw io.ReadWriter, encOwnerAuth []byte, encSRKAuth []byte, srk *key, ca *commandAuth) (*key, *responseAuth, uint32, error) {
+func takeOwnership(rw io.ReadWriter, encOwnerAuth tpmutil.U32Bytes, encSRKAuth tpmutil.U32Bytes, srk *key, ca *commandAuth) (*key, *responseAuth, uint32, error) {
 	in := []interface{}{pidOwner, encOwnerAuth, encSRKAuth, srk, ca}
 	var k key
 	var ra responseAuth
@@ -344,9 +344,9 @@ func createWrapKey(rw io.ReadWriter, encUsageAuth digest, encMigrationAuth diges
 	return &k, &ra, ret, nil
 }
 
-func sign(rw io.ReadWriter, keyHandle tpmutil.Handle, data []byte, ca *commandAuth) ([]byte, *responseAuth, uint32, error) {
+func sign(rw io.ReadWriter, keyHandle tpmutil.Handle, data tpmutil.U32Bytes, ca *commandAuth) ([]byte, *responseAuth, uint32, error) {
 	in := []interface{}{keyHandle, data, ca}
-	var signature []byte
+	var signature tpmutil.U32Bytes
 	var ra responseAuth
 	out := []interface{}{&signature, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordSign, in, out)

--- a/tpm/constants.go
+++ b/tpm/constants.go
@@ -16,11 +16,6 @@ package tpm
 
 import "github.com/google/go-tpm/tpmutil"
 
-func init() {
-	// TPM 1.2 spec uses uint32 for length prefix of byte arrays.
-	tpmutil.UseTPM12LengthPrefixSize()
-}
-
 // Supported TPM commands.
 const (
 	tagPCRInfoLong     uint16 = 0x06

--- a/tpm/structures.go
+++ b/tpm/structures.go
@@ -245,7 +245,7 @@ type pubKey struct {
 type symKey struct {
 	AlgID     uint32
 	EncScheme uint16
-	Key       tpmutil.U16Bytes
+	Key       tpmutil.U16Bytes // TPM_SYMMETRIC_KEY uses a 16-bit header for Key data
 }
 
 // A tpmStoredData holds sealed data from the TPM.

--- a/tpm/tpm_test.go
+++ b/tpm/tpm_test.go
@@ -216,13 +216,13 @@ func TestResizeableSlice(t *testing.T) {
 		t.Fatal("Couldn't read random bytes into the byte array")
 	}
 
-	bb, err := tpmutil.Pack(ra, b)
+	bb, err := tpmutil.Pack(ra, tpmutil.U32Bytes(b))
 	if err != nil {
 		t.Fatal("Couldn't pack the bytes:", err)
 	}
 
 	var ra2 responseAuth
-	var b2 []byte
+	var b2 tpmutil.U32Bytes
 	if _, err := tpmutil.Unpack(bb, &ra2, &b2); err != nil {
 		t.Fatal("Couldn't unpack the resizeable values:", err)
 	}

--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -25,10 +25,6 @@ import (
 	"github.com/google/go-tpm/tpmutil"
 )
 
-func init() {
-	tpmutil.UseTPM20LengthPrefixSize()
-}
-
 // MAX_DIGEST_BUFFER is the maximum size of []byte request or response fields.
 // Typically used for chunking of big blobs of data (such as for hashing or
 // encryption).

--- a/tpm2/credactivation/credential_activation.go
+++ b/tpm2/credactivation/credential_activation.go
@@ -95,7 +95,7 @@ func generateRSA(aik *tpm2.HashValue, pub *rsa.PublicKey, symBlockSize int, secr
 	if err != nil {
 		return nil, nil, fmt.Errorf("symmetric cipher setup: %v", err)
 	}
-	cv, err := tpmutil.Pack(secret)
+	cv, err := tpmutil.Pack(tpmutil.U16Bytes(secret))
 	if err != nil {
 		return nil, nil, fmt.Errorf("generating cv (TPM2B_Digest): %v", err)
 	}
@@ -125,7 +125,7 @@ func generateRSA(aik *tpm2.HashValue, pub *rsa.PublicKey, symBlockSize int, secr
 	if err != nil {
 		return nil, nil, fmt.Errorf("encoding IDObject: %v", err)
 	}
-	packedEncSecret, err := tpmutil.Pack(encSecret)
+	packedEncSecret, err := tpmutil.Pack(tpmutil.U16Bytes(encSecret))
 	if err != nil {
 		return nil, nil, fmt.Errorf("packing encSecret: %v", err)
 	}

--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -31,13 +31,13 @@ type NVPublic struct {
 	NVIndex    tpmutil.Handle
 	NameAlg    Algorithm
 	Attributes KeyProp
-	AuthPolicy []byte
+	AuthPolicy tpmutil.U16Bytes
 	DataSize   uint16
 }
 
 type tpmsSensitiveCreate struct {
-	UserAuth []byte
-	Data     []byte
+	UserAuth tpmutil.U16Bytes
+	Data     tpmutil.U16Bytes
 }
 
 // PCRSelection contains a slice of PCR indexes and a hash algorithm used in
@@ -58,7 +58,7 @@ type Public struct {
 	Type       Algorithm
 	NameAlg    Algorithm
 	Attributes KeyProp
-	AuthPolicy []byte
+	AuthPolicy tpmutil.U16Bytes
 
 	// If Type is AlgKeyedHash, then do not set these.
 	// Otherwise, only one of the Parameters fields should be set. When encoding/decoding,
@@ -161,7 +161,7 @@ type RSAParams struct {
 	// encoded bitstream, so Name digest calculations will be correct.
 	encodeDefaultExponentAsZero bool
 	Exponent                    uint32
-	ModulusRaw                  []byte
+	ModulusRaw                  tpmutil.U16Bytes
 	Modulus                     *big.Int
 }
 
@@ -194,7 +194,7 @@ func (p *RSAParams) encode() ([]byte, error) {
 	}
 	mod := p.ModulusRaw
 	if p.Modulus != nil {
-		mod = p.Modulus.Bytes()
+		mod = tpmutil.U16Bytes(p.Modulus.Bytes())
 	}
 	unique, err := tpmutil.Pack(mod)
 	if err != nil {
@@ -214,7 +214,7 @@ func decodeRSAParams(in *bytes.Buffer) (*RSAParams, error) {
 	if params.Sign, err = decodeSigScheme(in); err != nil {
 		return nil, fmt.Errorf("decoding Sign: %v", err)
 	}
-	var modBytes []byte
+	var modBytes tpmutil.U16Bytes
 	if err := tpmutil.UnpackBuf(in, &params.KeyBits, &params.Exponent, &modBytes); err != nil {
 		return nil, fmt.Errorf("decoding KeyBits, Exponent, Modulus: %v", err)
 	}
@@ -276,7 +276,8 @@ func (p *ECCParams) encode() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("encoding KDF: %v", err)
 	}
-	point, err := tpmutil.Pack(p.Point.x().Bytes(), p.Point.y().Bytes())
+	x, y := p.Point.x().Bytes(), p.Point.y().Bytes()
+	point, err := tpmutil.Pack(tpmutil.U16Bytes(x), tpmutil.U16Bytes(y))
 	if err != nil {
 		return nil, fmt.Errorf("encoding Point: %v", err)
 	}
@@ -299,7 +300,7 @@ func decodeECCParams(in *bytes.Buffer) (*ECCParams, error) {
 	if params.KDF, err = decodeKDFScheme(in); err != nil {
 		return nil, fmt.Errorf("decoding KDF: %v", err)
 	}
-	var x, y []byte
+	var x, y tpmutil.U16Bytes
 	if err := tpmutil.UnpackBuf(in, &x, &y); err != nil {
 		return nil, fmt.Errorf("decoding Point: %v", err)
 	}
@@ -311,7 +312,7 @@ func decodeECCParams(in *bytes.Buffer) (*ECCParams, error) {
 // SymCipherParams represents parameters of a symmetric block cipher TPM object.
 type SymCipherParams struct {
 	Symmetric *SymScheme
-	Unique    []byte
+	Unique    tpmutil.U16Bytes
 }
 
 func (p *SymCipherParams) encode() ([]byte, error) {
@@ -467,7 +468,7 @@ func decodeSignature(in *bytes.Buffer) (*Signature, error) {
 		}
 	case AlgECDSA:
 		sig.ECC = new(SignatureECC)
-		var r, s []byte
+		var r, s tpmutil.U16Bytes
 		if err := tpmutil.UnpackBuf(in, &sig.ECC.HashAlg, &r, &s); err != nil {
 			return nil, fmt.Errorf("decoding ECC: %v", err)
 		}
@@ -482,7 +483,7 @@ func decodeSignature(in *bytes.Buffer) (*Signature, error) {
 // SignatureRSA is an RSA-specific signature value.
 type SignatureRSA struct {
 	HashAlg   Algorithm
-	Signature []byte
+	Signature tpmutil.U16Bytes
 }
 
 // SignatureECC is an ECC-specific signature value.
@@ -495,9 +496,9 @@ type SignatureECC struct {
 // Private contains private section of a TPM key.
 type Private struct {
 	Type      Algorithm
-	AuthValue []byte
-	SeedValue []byte
-	Sensitive []byte
+	AuthValue tpmutil.U16Bytes
+	SeedValue tpmutil.U16Bytes
+	Sensitive tpmutil.U16Bytes
 }
 
 // Encode serializes a Private structure in TPM wire format.
@@ -518,7 +519,7 @@ type AttestationData struct {
 	Magic                uint32
 	Type                 tpmutil.Tag
 	QualifiedSigner      Name
-	ExtraData            []byte
+	ExtraData            tpmutil.U16Bytes
 	ClockInfo            ClockInfo
 	FirmwareVersion      uint64
 	AttestedCertifyInfo  *CertifyInfo
@@ -605,7 +606,7 @@ type CreationInfo struct {
 	// Most TPM2B_Digest structures contain a TPMU_HA structure
 	// and get parsed to HashValue. This is never the case for the
 	// digest in TPMS_CREATION_INFO.
-	OpaqueDigest []byte
+	OpaqueDigest tpmutil.U16Bytes
 }
 
 func decodeCreationInfo(in *bytes.Buffer) (*CreationInfo, error) {
@@ -677,7 +678,7 @@ func (ci CertifyInfo) encode() ([]byte, error) {
 // QuoteInfo represents a TPMS_QUOTE_INFO structure.
 type QuoteInfo struct {
 	PCRSelection PCRSelection
-	PCRDigest    []byte
+	PCRDigest    tpmutil.U16Bytes
 }
 
 func decodeQuoteInfo(in *bytes.Buffer) (*QuoteInfo, error) {
@@ -695,8 +696,8 @@ func decodeQuoteInfo(in *bytes.Buffer) (*QuoteInfo, error) {
 
 // IDObject represents an encrypted credential bound to a TPM object.
 type IDObject struct {
-	IntegrityHMAC []byte
-	EncIdentity   []byte
+	IntegrityHMAC tpmutil.U16Bytes
+	EncIdentity   tpmutil.RawBytes
 }
 
 // Encode packs the IDObject into a byte stream representing
@@ -704,23 +705,23 @@ type IDObject struct {
 func (o *IDObject) Encode() ([]byte, error) {
 	// encIdentity is packed raw, as the bytes representing the size
 	// of the credential value are present within the encrypted blob.
-	d, err := tpmutil.Pack(o.IntegrityHMAC, tpmutil.RawBytes(o.EncIdentity))
+	d, err := tpmutil.Pack(o.IntegrityHMAC, o.EncIdentity)
 	if err != nil {
 		return nil, fmt.Errorf("encoding IntegrityHMAC, EncIdentity: %v", err)
 	}
-	return tpmutil.Pack(d)
+	return tpmutil.Pack(tpmutil.U16Bytes(d))
 }
 
 // CreationData describes the attributes and environment for an object created
 // on the TPM. This structure encodes/decodes to/from TPMS_CREATION_DATA.
 type CreationData struct {
 	PCRSelection        PCRSelection
-	PCRDigest           []byte
+	PCRDigest           tpmutil.U16Bytes
 	Locality            byte
 	ParentNameAlg       Algorithm
 	ParentName          Name
 	ParentQualifiedName Name
-	OutsideInfo         []byte
+	OutsideInfo         tpmutil.U16Bytes
 }
 
 func (cd *CreationData) encode() ([]byte, error) {
@@ -788,7 +789,7 @@ type Name struct {
 }
 
 func decodeName(in *bytes.Buffer) (*Name, error) {
-	var nameBuf []byte
+	var nameBuf tpmutil.U16Bytes
 	if err := tpmutil.UnpackBuf(in, &nameBuf); err != nil {
 		return nil, err
 	}
@@ -827,7 +828,7 @@ func (n Name) encode() ([]byte, error) {
 	default:
 		// Name is empty, which is valid.
 	}
-	return tpmutil.Pack(buf)
+	return tpmutil.Pack(tpmutil.U16Bytes(buf))
 }
 
 // MatchesPublic compares Digest in Name against given Public structure. Note:
@@ -855,7 +856,7 @@ func (n Name) MatchesPublic(p Public) (bool, error) {
 // HashValue is an algorithm-specific hash value.
 type HashValue struct {
 	Alg   Algorithm
-	Value []byte
+	Value tpmutil.U16Bytes
 }
 
 func decodeHashValue(in *bytes.Buffer) (*HashValue, error) {
@@ -867,7 +868,7 @@ func decodeHashValue(in *bytes.Buffer) (*HashValue, error) {
 	if !ok {
 		return nil, fmt.Errorf("unsupported hash algorithm type 0x%x", hv.Alg)
 	}
-	hv.Value = make([]byte, hfn().Size())
+	hv.Value = make(tpmutil.U16Bytes, hfn().Size())
 	if _, err := in.Read(hv.Value); err != nil {
 		return nil, fmt.Errorf("decoding Value: %v", err)
 	}
@@ -910,7 +911,7 @@ type TaggedProperty struct {
 type Ticket struct {
 	Type      tpmutil.Tag
 	Hierarchy uint32
-	Digest    []byte
+	Digest    tpmutil.U16Bytes
 }
 
 func decodeTicket(in *bytes.Buffer) (*Ticket, error) {
@@ -925,7 +926,7 @@ func decodeTicket(in *bytes.Buffer) (*Ticket, error) {
 // which authorize the use of a given handle or parameter.
 type AuthCommand struct {
 	Session    tpmutil.Handle
-	Nonce      []byte
+	Nonce      tpmutil.U16Bytes
 	Attributes SessionAttributes
-	Auth       []byte
+	Auth       tpmutil.U16Bytes
 }

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -242,10 +242,10 @@ func TestCombinedEndorsementTest(t *testing.T) {
 		{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(emptyPassword)},
 	}, keyHandle, parentHandle, credBlob, encryptedSecret0)
 	if err == nil {
-		t.Fatal("ActivateCredentialUsingAuth: error == nil, expected response status 0x98e (authorization failure)")
+		t.Fatal("ActivateCredentialUsingAuth: error == nil, expected authorization failure")
 	}
-	if !strings.Contains(err.Error(), "0x98e") {
-		t.Errorf("ActivateCredentialUsingAuth: error = %v, expected response status 0x98e (authorization failure)", err)
+	if !strings.Contains(err.Error(), "the authorization HMAC check failed") {
+		t.Errorf("ActivateCredentialUsingAuth: error = %v, expected authorization failure", err)
 	}
 
 	_, err = ActivateCredentialUsingAuth(rw, []AuthCommand{

--- a/tpmutil/encoding.go
+++ b/tpmutil/encoding.go
@@ -23,78 +23,10 @@ import (
 	"reflect"
 )
 
-// lengthPrefixSize is the size in bytes of length prefix for byte slices.
-//
-// In TPM 1.2 this is 4 bytes.
-// In TPM 2.0 this is 2 bytes.
-var lengthPrefixSize int
-
-const (
-	tpm12PrefixSize = 4
-	tpm20PrefixSize = 2
+var (
+	selfMarshalerType = reflect.TypeOf((*SelfMarshaler)(nil)).Elem()
+	handlesAreaType   = reflect.TypeOf((*[]Handle)(nil))
 )
-
-// UseTPM12LengthPrefixSize makes Pack/Unpack use TPM 1.2 encoding for byte
-// arrays.
-func UseTPM12LengthPrefixSize() {
-	lengthPrefixSize = tpm12PrefixSize
-}
-
-// UseTPM20LengthPrefixSize makes Pack/Unpack use TPM 2.0 encoding for byte
-// arrays.
-func UseTPM20LengthPrefixSize() {
-	lengthPrefixSize = tpm20PrefixSize
-}
-
-// packedSize computes the size of a sequence of types that can be passed to
-// binary.Read or binary.Write.
-func packedSize(elts ...interface{}) (int, error) {
-	var size int
-	for _, e := range elts {
-		marshaler, ok := e.(SelfMarshaler)
-		if ok {
-			size += marshaler.TPMPackedSize()
-			continue
-		}
-		v := reflect.ValueOf(e)
-		switch v.Kind() {
-		case reflect.Ptr:
-			s, err := packedSize(reflect.Indirect(v).Interface())
-			if err != nil {
-				return 0, err
-			}
-
-			size += s
-		case reflect.Struct:
-			for i := 0; i < v.NumField(); i++ {
-				s, err := packedSize(v.Field(i).Interface())
-				if err != nil {
-					return 0, err
-				}
-
-				size += s
-			}
-		case reflect.Slice:
-			switch s := e.(type) {
-			case []byte:
-				size += lengthPrefixSize + len(s)
-			case RawBytes:
-				size += len(s)
-			default:
-				return 0, fmt.Errorf("encoding of %T is not supported, only []byte and RawBytes slices are", e)
-			}
-		default:
-			s := binary.Size(e)
-			if s < 0 {
-				return 0, fmt.Errorf("can't calculate size of type %T", e)
-			}
-
-			size += s
-		}
-	}
-
-	return size, nil
-}
 
 // packWithHeader takes a header and a sequence of elements that are either of
 // fixed length or slices of fixed-length types and packs them into a single
@@ -102,14 +34,17 @@ func packedSize(elts ...interface{}) (int, error) {
 // length.
 func packWithHeader(ch commandHeader, cmd ...interface{}) ([]byte, error) {
 	hdrSize := binary.Size(ch)
-	bodySize, err := packedSize(cmd...)
+	body, err := Pack(cmd...)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't compute packed size for message body: %v", err)
+		return nil, fmt.Errorf("couldn't pack message body: %v", err)
 	}
+	bodySize := binary.Size(body)
 	ch.Size = uint32(hdrSize + bodySize)
-	in := []interface{}{ch}
-	in = append(in, cmd...)
-	return Pack(in...)
+	header, err := Pack(ch)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't pack message header: %v", err)
+	}
+	return append(header, body...), nil
 }
 
 // Pack encodes a set of elements into a single byte array, using
@@ -120,79 +55,94 @@ func packWithHeader(ch commandHeader, cmd ...interface{}) ([]byte, error) {
 // prepended length, to match how the TPM encodes variable-length arrays. If
 // you wish to add a byte slice without length prefix, use RawBytes.
 func Pack(elts ...interface{}) ([]byte, error) {
-	if lengthPrefixSize == 0 {
-		return nil, errors.New("lengthPrefixSize must be initialized")
-	}
-
 	buf := new(bytes.Buffer)
 	if err := packType(buf, elts...); err != nil {
 		return nil, err
 	}
-
 	return buf.Bytes(), nil
 }
 
-// packType recursively packs types the same way that encoding/binary does
-// under binary.BigEndian, but with one difference: it packs a byte slice as a
-// lengthPrefixSize size followed by the bytes. The function unpackType
-// performs the inverse operation of unpacking slices stored in this manner and
-// using encoding/binary for everything else.
+// tryMarshal attempts to use a Marshal() method defined on the type
+// to pack v into buf. True is returned if the method exists and the
+// marshal was attempted.
+func tryMarshal(buf io.Writer, v reflect.Value) (bool, error) {
+	t := v.Type()
+	if t.Implements(selfMarshalerType) {
+		return true, v.Interface().(SelfMarshaler).TPMMarshal(buf)
+	}
+
+	// We might have a non-pointer struct field, but we dont have a
+	// pointer with which to implement the interface.
+	// If the pointer of the type implements the interface, we should be
+	// able to construct a value to call TPMUnmarshal() with.
+	if reflect.PtrTo(t).Implements(selfMarshalerType) {
+		tmp := reflect.New(t)
+		tmp.Elem().Set(v)
+		return true, tmp.Interface().(SelfMarshaler).TPMMarshal(buf)
+	}
+
+	return false, nil
+}
+
+func packValue(buf io.Writer, v reflect.Value) error {
+	if canMarshal, err := tryMarshal(buf, v); canMarshal {
+		return err
+	}
+
+	switch v.Kind() {
+	case reflect.Ptr:
+		if v.IsNil() {
+			return fmt.Errorf("cannot pack nil %s", v.Type().String())
+		}
+		return packValue(buf, v.Elem())
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			f := v.Field(i)
+			if err := packValue(buf, f); err != nil {
+				return err
+			}
+		}
+	default:
+		return binary.Write(buf, binary.BigEndian, v.Interface())
+	}
+	return nil
+}
+
 func packType(buf io.Writer, elts ...interface{}) error {
 	for _, e := range elts {
-		marshaler, ok := e.(SelfMarshaler)
-		if ok {
-			if err := marshaler.TPMMarshal(buf); err != nil {
-				return err
-			}
-			continue
+		if err := packValue(buf, reflect.ValueOf(e)); err != nil {
+			return err
 		}
-		v := reflect.ValueOf(e)
-		switch v.Kind() {
-		case reflect.Ptr:
-			if err := packType(buf, reflect.Indirect(v).Interface()); err != nil {
-				return err
-			}
-		case reflect.Struct:
-			// TODO(awly): Currently packType cannot handle non-struct fields that implement SelfMarshaler
-			for i := 0; i < v.NumField(); i++ {
-				if err := packType(buf, v.Field(i).Interface()); err != nil {
-					return err
-				}
-			}
-		case reflect.Slice:
-			switch s := e.(type) {
-			case []byte:
-				switch lengthPrefixSize {
-				case tpm20PrefixSize:
-					if err := binary.Write(buf, binary.BigEndian, uint16(len(s))); err != nil {
-						return err
-					}
-				case tpm12PrefixSize:
-					if err := binary.Write(buf, binary.BigEndian, uint32(len(s))); err != nil {
-						return err
-					}
-				default:
-					return fmt.Errorf("lengthPrefixSize is %d, must be either 2 or 4", lengthPrefixSize)
-				}
-				if err := binary.Write(buf, binary.BigEndian, s); err != nil {
-					return err
-				}
-			case RawBytes:
-				if err := binary.Write(buf, binary.BigEndian, s); err != nil {
-					return err
-				}
-			default:
-				return fmt.Errorf("only []byte and RawBytes slices are supported, got %T", e)
-			}
-		default:
-			if err := binary.Write(buf, binary.BigEndian, e); err != nil {
-				return err
-			}
-		}
-
 	}
 
 	return nil
+}
+
+// tryUnmarshal attempts to use TPMUnmarshal() to perform the
+// unpack, if the given value implements SelfMarshaler.
+// True is returned if v implements SelfMarshaler & TPMUnmarshal
+// was called, along with an error returned from TPMUnmarshal.
+func tryUnmarshal(buf io.Reader, v reflect.Value) (bool, error) {
+	t := v.Type()
+	if t.Implements(selfMarshalerType) {
+		return true, v.Interface().(SelfMarshaler).TPMUnmarshal(buf)
+	}
+
+	// We might have a non-pointer struct field, which is settable,
+	// but we dont have a pointer with which to implement the interface.
+	// If the pointer of the type implements the interface, and the
+	// value is settable, we should be able to construct a value to call
+	// TPMUnmarshal() with before replacing the value.
+	if v.CanSet() && reflect.PtrTo(t).Implements(selfMarshalerType) {
+		tmp := reflect.New(t)
+		if err := tmp.Interface().(SelfMarshaler).TPMUnmarshal(buf); err != nil {
+			return true, err
+		}
+		v.Set(tmp.Elem())
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // Unpack is a convenience wrapper around UnpackBuf. Unpack returns the number
@@ -204,6 +154,58 @@ func Unpack(b []byte, elts ...interface{}) (int, error) {
 	return read, err
 }
 
+func unpackValue(buf io.Reader, v reflect.Value) error {
+	if didUnmarshal, err := tryUnmarshal(buf, v); didUnmarshal {
+		return err
+	}
+
+	if v.Type() == handlesAreaType {
+		var numHandles uint16
+		if err := binary.Read(buf, binary.BigEndian, &numHandles); err != nil {
+			return err
+		}
+
+		// A zero size is used by the TPM to signal that certain elements
+		// are not present.
+		if int(numHandles) == 0 {
+			return nil
+		}
+
+		// Make len(e) match size exactly.
+		handlesArea := v.Interface().(*[]Handle)
+		areaLen := v.Elem().Len()
+		if areaLen >= int(numHandles) {
+			*handlesArea = (*handlesArea)[:int(numHandles)]
+		} else {
+			*handlesArea = append(*handlesArea, make([]Handle, int(numHandles)-areaLen)...)
+		}
+
+		return binary.Read(buf, binary.BigEndian, handlesArea)
+	}
+
+	switch v.Kind() {
+	case reflect.Ptr:
+		if v.IsNil() {
+			return fmt.Errorf("cannot pack nil %s", v.Type().String())
+		}
+		return unpackValue(buf, v.Elem())
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			f := v.Field(i)
+			if err := unpackValue(buf, f); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// binary.Read can only set pointer values, so we need to take the address.
+	if !v.CanAddr() {
+		return fmt.Errorf("cannot unpack unaddressable leaf type %q", v.Type().String())
+	}
+	return binary.Read(buf, binary.BigEndian, v.Addr().Interface())
+}
+
 // UnpackBuf recursively unpacks types from a reader just as encoding/binary
 // does under binary.BigEndian, but with one difference: it unpacks a byte
 // slice by first reading an integer with lengthPrefixSize bytes, then reading
@@ -212,95 +214,16 @@ func Unpack(b []byte, elts ...interface{}) (int, error) {
 func UnpackBuf(buf io.Reader, elts ...interface{}) error {
 	for _, e := range elts {
 		v := reflect.ValueOf(e)
-		k := v.Kind()
-		if k != reflect.Ptr {
-			return fmt.Errorf("all values passed to Unpack must be pointers, got %v", k)
+		if v.Kind() != reflect.Ptr {
+			return fmt.Errorf("non-pointer value %q passed to UnpackBuf", v.Type().String())
 		}
-
 		if v.IsNil() {
-			return errors.New("can't fill a nil pointer")
+			return errors.New("nill pointer passed to UnpackBuf")
 		}
 
-		marshaler, ok := e.(SelfMarshaler)
-		if ok {
-			if err := marshaler.TPMUnmarshal(buf); err != nil {
-				return err
-			}
-			continue
+		if err := unpackValue(buf, v); err != nil {
+			return err
 		}
-		iv := reflect.Indirect(v)
-		switch iv.Kind() {
-		case reflect.Struct:
-			// Decompose the struct and copy over the values.
-			for i := 0; i < iv.NumField(); i++ {
-				if err := UnpackBuf(buf, iv.Field(i).Addr().Interface()); err != nil {
-					return err
-				}
-			}
-		case reflect.Slice:
-			var size int
-			_, isHandles := e.(*[]Handle)
-
-			switch {
-			// []Handle always uses 2-byte length, even with TPM 1.2.
-			case isHandles:
-				var tmpSize uint16
-				if err := binary.Read(buf, binary.BigEndian, &tmpSize); err != nil {
-					return err
-				}
-				size = int(tmpSize)
-			// TPM 2.0
-			case lengthPrefixSize == tpm20PrefixSize:
-				var tmpSize uint16
-				if err := binary.Read(buf, binary.BigEndian, &tmpSize); err != nil {
-					return err
-				}
-				size = int(tmpSize)
-			// TPM 1.2
-			case lengthPrefixSize == tpm12PrefixSize:
-				var tmpSize uint32
-				if err := binary.Read(buf, binary.BigEndian, &tmpSize); err != nil {
-					return err
-				}
-				size = int(tmpSize)
-			default:
-				return fmt.Errorf("lengthPrefixSize is %d, must be either 2 or 4", lengthPrefixSize)
-			}
-
-			// A zero size is used by the TPM to signal that certain elements
-			// are not present.
-			if size == 0 {
-				continue
-			}
-
-			// Make len(e) match size exactly.
-			switch b := e.(type) {
-			case *[]byte:
-				if len(*b) >= size {
-					*b = (*b)[:size]
-				} else {
-					*b = append(*b, make([]byte, size-len(*b))...)
-				}
-			case *[]Handle:
-				if len(*b) >= size {
-					*b = (*b)[:size]
-				} else {
-					*b = append(*b, make([]Handle, size-len(*b))...)
-				}
-			default:
-				return fmt.Errorf("can't fill pointer to %T, only []byte or []Handle slices", e)
-			}
-
-			if err := binary.Read(buf, binary.BigEndian, e); err != nil {
-				return err
-			}
-		default:
-			if err := binary.Read(buf, binary.BigEndian, e); err != nil {
-				return err
-			}
-		}
-
 	}
-
 	return nil
 }

--- a/tpmutil/encoding.go
+++ b/tpmutil/encoding.go
@@ -38,7 +38,7 @@ func packWithHeader(ch commandHeader, cmd ...interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("couldn't pack message body: %v", err)
 	}
-	bodySize := binary.Size(body)
+	bodySize := len(body)
 	ch.Size = uint32(hdrSize + bodySize)
 	header, err := Pack(ch)
 	if err != nil {
@@ -69,7 +69,7 @@ func tryMarshal(buf io.Writer, v reflect.Value) (bool, error) {
 	t := v.Type()
 	if t.Implements(selfMarshalerType) {
 		if v.Kind() == reflect.Ptr && v.IsNil() {
-			return true, fmt.Errorf("cannot call TPMMarshal on a nil pointer")
+			return true, fmt.Errorf("cannot call TPMMarshal on a nil pointer of type %T", v)
 		}
 		return true, v.Interface().(SelfMarshaler).TPMMarshal(buf)
 	}
@@ -206,7 +206,7 @@ func UnpackBuf(buf io.Reader, elts ...interface{}) error {
 			return fmt.Errorf("non-pointer value %q passed to UnpackBuf", v.Type().String())
 		}
 		if v.IsNil() {
-			return errors.New("nill pointer passed to UnpackBuf")
+			return errors.New("nil pointer passed to UnpackBuf")
 		}
 
 		if err := unpackValue(buf, v); err != nil {

--- a/tpmutil/encoding_test.go
+++ b/tpmutil/encoding_test.go
@@ -217,62 +217,29 @@ func TestEncodingInvalidUnpack(t *testing.T) {
 }
 
 func TestSelfMarshaler(t *testing.T) {
-	var b U32Bytes
-	// The slice ui represents uint32(0), which is the length of an empty byte array.
-	ui := []byte{0, 0, 0, 0}
-	uiBuf := bytes.NewBuffer(ui)
-	if err := UnpackBuf(uiBuf, &b); err != nil {
-		t.Fatal("UnpackBuf failed to unpack the empty byte array")
+	var empty16 U16Bytes
+	var empty32 U32Bytes
+	subTests := []struct {
+		encoded []byte
+		decoded interface{}
+	}{
+		{[]byte{0, 0}, &empty16},
+		{[]byte{0, 1, 137}, &empty16},
+		{[]byte{0, 0, 0, 0}, &empty32},
+		{[]byte{0, 0, 0, 1, 137}, &empty32},
 	}
-	pb, err := Pack(&b)
-	if err != nil {
-		t.Fatalf("Pack failed on U32Bytes")
-	}
-	if !bytes.Equal(pb, ui) {
-		t.Fatal("Pack failed to pack U32Bytes properly:", pb)
-	}
-
-	// A byte slice of length 1 with a single entry: b[0] == 137
-	ui2 := []byte{0, 0, 0, 1, 137}
-	uiBuf2 := bytes.NewBuffer(ui2)
-	if err := UnpackBuf(uiBuf2, &b); err != nil {
-		t.Fatal("UnpackBuf failed to unpack a byte array with a single value in it")
-	}
-	pb2, err := Pack(&b)
-	if err != nil {
-		t.Fatalf("Pack failed on U32Bytes")
-	}
-	if !bytes.Equal(pb2, ui2) {
-		t.Fatal("Pack failed to pack U32Bytes properly:", pb2)
-	}
-
-	var b2 U16Bytes
-	// The slice ui represents uint16(0), which is the length of an empty byte array.
-	ui3 := []byte{0, 0}
-	uiBuf3 := bytes.NewBuffer(ui3)
-	if err := UnpackBuf(uiBuf3, &b2); err != nil {
-		t.Fatal("UnpackBuf failed to unpack the empty byte array")
-	}
-	pb3, err := Pack(&b2)
-	if err != nil {
-		t.Fatalf("Pack failed on U16Bytes")
-	}
-	if !bytes.Equal(pb3, ui3) {
-		t.Fatal("Pack failed to pack U16Bytes properly:", pb3)
-	}
-
-	// A byte slice of length 1 with a single entry: b[0] == 137
-	ui4 := []byte{0, 1, 137}
-	uiBuf4 := bytes.NewBuffer(ui4)
-	if err := UnpackBuf(uiBuf4, &b2); err != nil {
-		t.Fatal("UnpackBuf failed to unpack a byte array with a single value in it")
-	}
-	pb4, err := Pack(&b2)
-	if err != nil {
-		t.Fatalf("Pack failed on U16Bytes")
-	}
-	if !bytes.Equal(pb4, ui4) {
-		t.Fatal("Pack failed to pack U16Bytes properly:", pb4)
+	for _, st := range subTests {
+		buffer := bytes.NewBuffer(st.encoded)
+		if err := UnpackBuf(buffer, st.decoded); err != nil {
+			t.Fatal("UnpackBuf failed:", err)
+		}
+		packed, err := Pack(st.decoded)
+		if err != nil {
+			t.Fatal("Pack failed:", err)
+		}
+		if !bytes.Equal(packed, st.encoded) {
+			t.Fatalf("Pack failed: expected %#v, got %#v", st.encoded, packed)
+		}
 	}
 }
 

--- a/tpmutil/encoding_test.go
+++ b/tpmutil/encoding_test.go
@@ -229,16 +229,17 @@ func TestSelfMarshaler(t *testing.T) {
 		{[]byte{0, 0, 0, 1, 137}, &empty32},
 	}
 	for _, st := range subTests {
+		t.Logf("Attempting to Marshal/Unmarshal %#v into %T", st.encoded, st.decoded)
 		buffer := bytes.NewBuffer(st.encoded)
 		if err := UnpackBuf(buffer, st.decoded); err != nil {
-			t.Fatal("UnpackBuf failed:", err)
+			t.Fatalf("UnpackBuf failed: %v", err)
 		}
 		packed, err := Pack(st.decoded)
 		if err != nil {
-			t.Fatal("Pack failed:", err)
+			t.Fatalf("Pack failed: %v", err)
 		}
 		if !bytes.Equal(packed, st.encoded) {
-			t.Fatalf("Pack failed: expected %#v, got %#v", st.encoded, packed)
+			t.Fatalf("Pack failed: got %#v, want: %#v", packed, st.encoded)
 		}
 	}
 }

--- a/tpmutil/run.go
+++ b/tpmutil/run.go
@@ -13,10 +13,6 @@
 // limitations under the License.
 
 // Package tpmutil provides common utility functions for both TPM 1.2 and TPM 2.0 devices.
-//
-// Users should call either UseTPM12LengthPrefixSize or
-// UseTPM20LengthPrefixSize before using this package, depending on their type
-// of TPM device.
 package tpmutil
 
 import (

--- a/tpmutil/structures.go
+++ b/tpmutil/structures.go
@@ -144,7 +144,7 @@ type Handle uint32
 type handleList []Handle
 
 func (l *handleList) TPMMarshal(out io.Writer) error {
-	return fmt.Errorf("TPM should never marshal []Handle")
+	return fmt.Errorf("TPMMarhsal on []Handle is not supported yet")
 }
 
 func (l *handleList) TPMUnmarshal(in io.Reader) error {

--- a/tpmutil/structures.go
+++ b/tpmutil/structures.go
@@ -16,6 +16,7 @@ package tpmutil
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 )
 
@@ -33,7 +34,15 @@ func (b *U16Bytes) TPMMarshal(out io.Writer) error {
 	if err := binary.Write(out, binary.BigEndian, size); err != nil {
 		return err
 	}
-	return binary.Write(out, binary.BigEndian, *b)
+
+	n, err := out.Write(*b)
+	if err != nil {
+		return err
+	}
+	if n != int(size) {
+		return fmt.Errorf("unable to write all contents of U16Bytes")
+	}
+	return nil
 }
 
 // TPMUnmarshal unpacks a U16Bytes
@@ -49,7 +58,14 @@ func (b *U16Bytes) TPMUnmarshal(in io.Reader) error {
 		*b = append(*b, make([]byte, size-len(*b))...)
 	}
 
-	return binary.Read(in, binary.BigEndian, b)
+	n, err := in.Read(*b)
+	if err != nil {
+		return err
+	}
+	if n != size {
+		return fmt.Errorf("unable to read all contents in to U16Bytes")
+	}
+	return nil
 }
 
 // U32Bytes is a byte slice with a 32-bit header
@@ -61,7 +77,15 @@ func (b *U32Bytes) TPMMarshal(out io.Writer) error {
 	if err := binary.Write(out, binary.BigEndian, size); err != nil {
 		return err
 	}
-	return binary.Write(out, binary.BigEndian, *b)
+
+	n, err := out.Write(*b)
+	if err != nil {
+		return err
+	}
+	if n != int(size) {
+		return fmt.Errorf("unable to write all contents of U32Bytes")
+	}
+	return nil
 }
 
 // TPMUnmarshal unpacks a U32Bytes
@@ -77,7 +101,14 @@ func (b *U32Bytes) TPMUnmarshal(in io.Reader) error {
 		*b = append(*b, make([]byte, size-len(*b))...)
 	}
 
-	return binary.Read(in, binary.BigEndian, b)
+	n, err := in.Read(*b)
+	if err != nil {
+		return err
+	}
+	if n != size {
+		return fmt.Errorf("unable to read all contents in to U32Bytes")
+	}
+	return nil
 }
 
 // Tag is a command tag.

--- a/tpmutil/structures.go
+++ b/tpmutil/structures.go
@@ -33,10 +33,7 @@ func (b *U16Bytes) TPMMarshal(out io.Writer) error {
 	if err := binary.Write(out, binary.BigEndian, size); err != nil {
 		return err
 	}
-	if err := binary.Write(out, binary.BigEndian, []byte(*b)); err != nil {
-		return err
-	}
-	return nil
+	return binary.Write(out, binary.BigEndian, *b)
 }
 
 // TPMUnmarshal unpacks a U16Bytes
@@ -52,10 +49,7 @@ func (b *U16Bytes) TPMUnmarshal(in io.Reader) error {
 		*b = append(*b, make([]byte, size-len(*b))...)
 	}
 
-	if err := binary.Read(in, binary.BigEndian, b); err != nil {
-		return err
-	}
-	return nil
+	return binary.Read(in, binary.BigEndian, b)
 }
 
 // U32Bytes is a byte slice with a 32-bit header
@@ -67,10 +61,7 @@ func (b *U32Bytes) TPMMarshal(out io.Writer) error {
 	if err := binary.Write(out, binary.BigEndian, size); err != nil {
 		return err
 	}
-	if err := binary.Write(out, binary.BigEndian, []byte(*b)); err != nil {
-		return err
-	}
-	return nil
+	return binary.Write(out, binary.BigEndian, *b)
 }
 
 // TPMUnmarshal unpacks a U32Bytes
@@ -86,10 +77,7 @@ func (b *U32Bytes) TPMUnmarshal(in io.Reader) error {
 		*b = append(*b, make([]byte, size-len(*b))...)
 	}
 
-	if err := binary.Read(in, binary.BigEndian, b); err != nil {
-		return err
-	}
-	return nil
+	return binary.Read(in, binary.BigEndian, b)
 }
 
 // Tag is a command tag.


### PR DESCRIPTION
Replace global prefix size with U32Bytes and U16Bytes
Modify tpm1.2 and tpm2.0 commands to use these types instead of []byte
@twitchy-jsonp did most of the heavy lifting rewriting tpmutil/encoding.go to use reflect.Value instead of {}interface.