### PR TITLE
tpm2: actually fail when tpmutil.RunCommand returns an error

### DIFF
--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1308,7 +1308,10 @@ func CertifyCreation(rw io.ReadWriter, objectAuth string, object, signer tpmutil
 
 func runCommand(rw io.ReadWriter, tag tpmutil.Tag, cmd tpmutil.Command, in ...interface{}) ([]byte, error) {
 	resp, code, err := tpmutil.RunCommand(rw, tag, cmd, in...)
-	if err != nil || code != tpmutil.RCSuccess {
+	if err != nil {
+		return nil, err
+	}
+	if code != tpmutil.RCSuccess {
 		return nil, decodeResponse(code)
 	}
 	return resp, decodeResponse(code)

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -99,6 +99,14 @@ var (
 	emptyPassword   = ""
 )
 
+func TestRunCommandErr(t *testing.T) {
+	// nil ReadWriter handle will cause tpmutil.RunCommand to return an error
+	// immediately.
+	if _, err := runCommand(nil, TagSessions, cmdSign); err == nil {
+		t.Error("runCommand returned nil error on error from tpmutil.RunCommand")
+	}
+}
+
 func TestGetRandom(t *testing.T) {
 	rw := openTPM(t)
 	defer rw.Close()


### PR DESCRIPTION
This is embarrassing :(
tpmutil.RCSuccess matching the zero value doesn't help either.