### PR TITLE
Fix tpm2.CreatePrimaryRawTemplate return value

### DIFF
--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -488,8 +488,17 @@ func CreatePrimaryRawTemplate(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSel
 		return 0, nil, err
 	}
 
-	hnd, pub, _, _, _, _, err := decodeCreatePrimary(resp)
-	return hnd, pub, err
+	hnd, public, _, _, _, _, err := decodeCreatePrimary(resp)
+	pub, err := DecodePublic(public)
+	if err != nil {
+		return 0, nil, fmt.Errorf("parsing public: %v", err)
+	}
+
+	pubKey, err := pub.Key()
+	if err != nil {
+		return 0, nil, fmt.Errorf("extracting cryto.PublicKey from Public part of primary key: %v", err)
+	}
+	return hnd, pubKey, nil
 }
 
 func decodeReadPublic(in []byte) (Public, []byte, []byte, error) {


### PR DESCRIPTION
This was broken in https://github.com/google/go-tpm/pull/50 because we
started returning raw encoded Public data for the key instead of parsed
crypto.PublicKey.
This didn't get caught because we had no tests and because []byte
implements crypto.PublicKey (it's an empty interface).