### PR TITLE
Detect version of TPM in OpenTPM()

### DIFF
--- a/tpm/open_other.go
+++ b/tpm/open_other.go
@@ -1,0 +1,42 @@
+// +build !windows
+
+// Copyright (c) 2019, Google LLC All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpm
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/google/go-tpm/tpmutil"
+)
+
+// OpenTPM opens a channel to the TPM at the given path. If the file is a
+// device, then it treats it like a normal TPM device, and if the file is a
+// Unix domain socket, then it opens a connection to the socket.
+func OpenTPM(path string) (io.ReadWriteCloser, error) {
+	rwc, err := tpmutil.OpenTPM(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Make sure this is a TPM 1.2
+	_, err = GetManufacturer(rwc)
+	if err != nil {
+		rwc.Close()
+		return nil, fmt.Errorf("open %s: device is not a TPM 1.2", path)
+	}
+	return rwc, nil
+}

--- a/tpm/open_windows.go
+++ b/tpm/open_windows.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2018, Google LLC All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpm
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/google/go-tpm/tpmutil"
+	"github.com/google/go-tpm/tpmutil/tbs"
+)
+
+// OpenTPM opens a channel to the TPM.
+func OpenTPM() (io.ReadWriteCloser, error) {
+	info, err := tbs.GetDeviceInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	if info.TPMVersion != tbs.TPMVersion12 {
+		return nil, fmt.Errorf("openTPM: device is not a TPM 1.2")
+	}
+
+	return tpmutil.OpenTPM()
+}

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -32,11 +32,6 @@ import (
 	"github.com/google/go-tpm/tpmutil"
 )
 
-// OpenTPM opens a channel to the TPM at the given path. If the file is a
-// device, then it treats it like a normal TPM device, and if the file is a
-// Unix domain socket, then it opens a connection to the socket.
-var OpenTPM = tpmutil.OpenTPM
-
 // GetKeys gets the list of handles for currently-loaded TPM keys.
 func GetKeys(rw io.ReadWriter) ([]tpmutil.Handle, error) {
 	b, err := getCapability(rw, capHandle, rtKey)

--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -157,9 +157,57 @@ const (
 // TPMProp represents the index of a TPM property in a call to GetCapability().
 type TPMProp uint32
 
-// TPM Capability Properties.
+// TPM Capability Properties, see TPM 2.0 Spec, Rev 1.38, Table 23
 const (
-	NVMaxBufferSize    TPMProp = 0x100 + 44
+	// Fixed TPM Properties (PT_FIXED)
+	FamilyIndicator TPMProp = 0x100 + iota
+	SpecLevel
+	SpecRevision
+	SpecDayOfYear
+	SpecYear
+	Manufacturer
+	VendorString1
+	VendorString2
+	VendorString3
+	VendorString4
+	VendorTPMType
+	FirmwareVersion1
+	FirmwareVersion2
+	InputMaxBufferSize
+	TransientObjectsMin
+	PersistentObjectsMin
+	LoadedObjectsMin
+	ActiveSessionsMax
+	PCRCount
+	PCRSelectMin
+	ContextGapMax
+	_ // (PT_FIXED + 21) is skipped
+	NVCountersMax
+	NVIndexMax
+	MemoryMethod
+	ClockUpdate
+	ContextHash
+	ContextSym
+	ContextSymSize
+	OrderlyCount
+	CommandMaxSize
+	ResponseMaxSize
+	DigestMaxSize
+	ObjectContextMaxSize
+	SessionContextMaxSize
+	PSFamilyIndicator
+	PSSpecLevel
+	PSSpecRevision
+	PSSpecDayOfYear
+	PSSpecYear
+	SplitSigningMax
+	TotalCommands
+	LibraryCommands
+	VendorCommands
+	NVMaxBufferSize
+	TPMModes
+	CapabilityMaxBufferSize
+
 	PCRFirst           TPMProp = 0x00000000
 	HMACSessionFirst   TPMProp = 0x02000000
 	LoadedSessionFirst TPMProp = 0x02000000

--- a/tpm2/open_other.go
+++ b/tpm2/open_other.go
@@ -1,0 +1,42 @@
+// +build !windows
+
+// Copyright (c) 2019, Google LLC All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpm2
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/google/go-tpm/tpmutil"
+)
+
+// OpenTPM opens a channel to the TPM at the given path. If the file is a
+// device, then it treats it like a normal TPM device, and if the file is a
+// Unix domain socket, then it opens a connection to the socket.
+func OpenTPM(path string) (io.ReadWriteCloser, error) {
+	rwc, err := tpmutil.OpenTPM(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Make sure this is a TPM 2.0
+	_, err = GetManufacturer(rwc)
+	if err != nil {
+		rwc.Close()
+		return nil, fmt.Errorf("open %s: device is not a TPM 2.0", path)
+	}
+	return rwc, nil
+}

--- a/tpm2/open_windows.go
+++ b/tpm2/open_windows.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2018, Google LLC All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpm2
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/google/go-tpm/tpmutil"
+	"github.com/google/go-tpm/tpmutil/tbs"
+)
+
+// OpenTPM opens a channel to the TPM.
+func OpenTPM() (io.ReadWriteCloser, error) {
+	info, err := tbs.GetDeviceInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	if info.TPMVersion != tbs.TPMVersion20 {
+		return nil, fmt.Errorf("openTPM: device is not a TPM 2.0")
+	}
+
+	return tpmutil.OpenTPM()
+}

--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -899,12 +899,9 @@ type AlgorithmDescription struct {
 	Attributes AlgorithmAttributes
 }
 
-// PropertyTag represents a TPM_PT value.
-type PropertyTag uint32
-
 // TaggedProperty represents a TPMS_TAGGED_PROPERTY structure.
 type TaggedProperty struct {
-	Tag   PropertyTag
+	Tag   TPMProp
 	Value uint32
 }
 

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -309,6 +309,17 @@ func GetCapability(rw io.ReadWriter, capa Capability, count, property uint32) (v
 	return decodeGetCapability(resp)
 }
 
+// GetManufacturer returns the manufacturer ID
+func GetManufacturer(rw io.ReadWriter) ([]byte, error) {
+	caps, _, err := GetCapability(rw, CapabilityTPMProperties, 1, uint32(Manufacturer))
+	if err != nil {
+		return nil, err
+	}
+
+	prop := caps[0].(TaggedProperty)
+	return tpmutil.Pack(prop.Value)
+}
+
 func encodeAuthArea(sections ...AuthCommand) ([]byte, error) {
 	var res tpmutil.RawBytes
 	for _, s := range sections {

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -24,11 +24,6 @@ import (
 	"github.com/google/go-tpm/tpmutil"
 )
 
-// OpenTPM opens a channel to the TPM at the given path. If the file is a
-// device, then it treats it like a normal TPM device, and if the file is a
-// Unix domain socket, then it opens a connection to the socket.
-var OpenTPM = tpmutil.OpenTPM
-
 // GetRandom gets random bytes from the TPM.
 func GetRandom(rw io.ReadWriter, size uint16) ([]byte, error) {
 	resp, err := runCommand(rw, TagNoSessions, cmdGetRandom, size)

--- a/tpmutil/tbs/tbs_windows.go
+++ b/tpmutil/tbs/tbs_windows.go
@@ -130,6 +130,7 @@ var errorDescriptions = map[Error]string{
 // https://docs.microsoft.com/en-us/windows/desktop/TBS/tpm-base-services-portal
 var (
 	tbsDLL           = syscall.NewLazyDLL("Tbs.dll")
+	tbsGetDeviceInfo = tbsDLL.NewProc("Tbsi_GetDeviceInfo")
 	tbsCreateContext = tbsDLL.NewProc("Tbsi_Context_Create")
 	tbsContextClose  = tbsDLL.NewProc("Tbsip_Context_Close")
 	tbsSubmitCommand = tbsDLL.NewProc("Tbsip_Submit_Command")
@@ -142,6 +143,27 @@ func sliceAddress(s []byte) uintptr {
 		return 0
 	}
 	return uintptr(unsafe.Pointer(&(s[0])))
+}
+
+// Declaration of TPM_DEVICE_INFO from tbs.h
+type DeviceInfo struct {
+	StructVersion    uint32
+	TPMVersion       Version
+	TPMInterfaceType uint32
+	TPMImpRevision   uint32
+}
+
+func GetDeviceInfo() (*DeviceInfo, error) {
+	info := DeviceInfo{}
+	// TBS_RESULT Tbsi_GetDeviceInfo(
+	//   UINT32 Size,
+	//   PVOID  Info
+	// );
+	result, _, _ := tbsGetDeviceInfo.Call(
+		unsafe.Sizeof(info),
+		uintptr(unsafe.Pointer(&info)),
+	)
+	return &info, getError(result)
 }
 
 // CreateContext creates a new TPM context:


### PR DESCRIPTION
This PR improves the error messages when using the `tpm2` library with a TPM 1.2 or vice-versa.

Before, the user would get an opaque input/output error. Now they get
```
Error: open /dev/tpm0: device is not a TPM 2.0
```

On Windows, this detection is done using [Tbsi_GetDeviceInfo](https://docs.microsoft.com/en-us/windows/desktop/api/tbs/nf-tbs-tbsi_getdeviceinfo), which required adding a binding to `tpmutil/tbs`.

On Linux/Unix, this detection is done by trying to issue a call to `GetManufacturer()`. Per the TPM spec, this call succeeds even if the TPM is in failure mode. This required adding some `TPM_PT` constants and `GetManufacturer()` wrapper function to `tpm2`.

See the commit history if you want to see the individual parts of this change.

Note: This command removes `PropertyTag` in favor of `TPMProp`. While `PropertyTag` is not used anywhere, this is technically a breaking change.