### PR TITLE
Implement some additional hierarchy control and dictionary attack functions for TPM2

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -307,6 +307,7 @@ const (
 	cmdEvictControl               tpmutil.Command = 0x00000120
 	cmdUndefineSpace              tpmutil.Command = 0x00000122
 	cmdClear                      tpmutil.Command = 0x00000126
+	cmdClearControl		      tpmutil.Command = 0x00000127
 	cmdClockSet                   tpmutil.Command = 0x00000128
 	cmdHierarchyChangeAuth        tpmutil.Command = 0x00000129
 	cmdDefineSpace                tpmutil.Command = 0x0000012A

--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -308,6 +308,7 @@ const (
 	cmdUndefineSpace              tpmutil.Command = 0x00000122
 	cmdClear                      tpmutil.Command = 0x00000126
 	cmdClockSet                   tpmutil.Command = 0x00000128
+	cmdHierarchyChangeAuth        tpmutil.Command = 0x00000129
 	cmdDefineSpace                tpmutil.Command = 0x0000012A
 	cmdPCRAllocate                tpmutil.Command = 0x0000012B
 	cmdCreatePrimary              tpmutil.Command = 0x00000131

--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -304,23 +304,24 @@ var toGoCurve = map[EllipticCurve]elliptic.Curve{
 
 // Supported TPM operations.
 const (
-	cmdEvictControl       tpmutil.Command = 0x00000120
-	cmdUndefineSpace      tpmutil.Command = 0x00000122
-	cmdClear	      tpmutil.Command = 0x00000126
-	cmdClockSet           tpmutil.Command = 0x00000128
-	cmdDefineSpace        tpmutil.Command = 0x0000012A
-	cmdPCRAllocate        tpmutil.Command = 0x0000012B
-	cmdCreatePrimary      tpmutil.Command = 0x00000131
-	cmdIncrementNVCounter tpmutil.Command = 0x00000134
-	cmdWriteNV            tpmutil.Command = 0x00000137
-	cmdPCREvent           tpmutil.Command = 0x0000013C
-	cmdStartup            tpmutil.Command = 0x00000144
-	cmdShutdown           tpmutil.Command = 0x00000145
-	cmdStirRandom         tpmutil.Command = 0x00000146
-	cmdActivateCredential tpmutil.Command = 0x00000147
-	cmdCertify            tpmutil.Command = 0x00000148
-	cmdCertifyCreation    tpmutil.Command = 0x0000014A
-	cmdReadNV             tpmutil.Command = 0x0000014E
+	cmdEvictControl               tpmutil.Command = 0x00000120
+	cmdUndefineSpace              tpmutil.Command = 0x00000122
+	cmdClear                      tpmutil.Command = 0x00000126
+	cmdClockSet                   tpmutil.Command = 0x00000128
+	cmdDefineSpace                tpmutil.Command = 0x0000012A
+	cmdPCRAllocate                tpmutil.Command = 0x0000012B
+	cmdCreatePrimary              tpmutil.Command = 0x00000131
+	cmdIncrementNVCounter         tpmutil.Command = 0x00000134
+	cmdWriteNV                    tpmutil.Command = 0x00000137
+	cmdPCREvent                   tpmutil.Command = 0x0000013C
+	cmdDictionaryAttackParameters tpmutil.Command = 0x0000013A
+	cmdStartup                    tpmutil.Command = 0x00000144
+	cmdShutdown                   tpmutil.Command = 0x00000145
+	cmdStirRandom                 tpmutil.Command = 0x00000146
+	cmdActivateCredential         tpmutil.Command = 0x00000147
+	cmdCertify                    tpmutil.Command = 0x00000148
+	cmdCertifyCreation            tpmutil.Command = 0x0000014A
+	cmdReadNV                     tpmutil.Command = 0x0000014E
 	// CmdPolicySecret is a command code for TPM2_PolicySecret.
 	// It's exported for computing of default AuthPolicy value.
 	CmdPolicySecret     tpmutil.Command = 0x00000151

--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -306,6 +306,7 @@ var toGoCurve = map[EllipticCurve]elliptic.Curve{
 const (
 	cmdEvictControl       tpmutil.Command = 0x00000120
 	cmdUndefineSpace      tpmutil.Command = 0x00000122
+	cmdClear	      tpmutil.Command = 0x00000126
 	cmdClockSet           tpmutil.Command = 0x00000128
 	cmdDefineSpace        tpmutil.Command = 0x0000012A
 	cmdPCRAllocate        tpmutil.Command = 0x0000012B


### PR DESCRIPTION
This adds API's for clearing the TPM, disabling the ability to clear the TPM with owner authorization, changing the hierarchy authorization values and configuring dictionary attack parameters.