### PR TITLE
Fix parameter decoding on TPM2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.test
+.vscode*

--- a/tpm2/encoding_test.go
+++ b/tpm2/encoding_test.go
@@ -219,7 +219,7 @@ func TestDecodeCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, _, _, _, _, _, err = decodeCreate(testRespBytes[10:]); err != nil {
+	if _, _, _, _, _, err = decodeCreate(testRespBytes[10:]); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -179,7 +179,7 @@ func TestCombinedKeyTest(t *testing.T) {
 	}
 	defer FlushContext(rw, parentHandle)
 
-	_, privateBlob, publicBlob, _, _, _, err := CreateKey(rw, parentHandle, pcrSelection7, defaultPassword, defaultPassword, defaultKeyParams)
+	privateBlob, publicBlob, _, _, _, err := CreateKey(rw, parentHandle, pcrSelection7, defaultPassword, defaultPassword, defaultKeyParams)
 	if err != nil {
 		t.Fatalf("CreateKey failed: %s", err)
 	}
@@ -205,7 +205,7 @@ func TestCombinedEndorsementTest(t *testing.T) {
 	}
 	defer FlushContext(rw, parentHandle)
 
-	_, privateBlob, publicBlob, _, _, _, err := CreateKey(rw, parentHandle, pcrSelection7, emptyPassword, defaultPassword, defaultKeyParams)
+	privateBlob, publicBlob, _, _, _, err := CreateKey(rw, parentHandle, pcrSelection7, emptyPassword, defaultPassword, defaultKeyParams)
 	if err != nil {
 		t.Fatalf("CreateKey failed: %s", err)
 	}
@@ -313,7 +313,7 @@ func TestCombinedContextTest(t *testing.T) {
 	defer FlushContext(rw, rootHandle)
 
 	// CreateKey (Quote Key)
-	_, quotePrivate, quotePublic, _, _, _, err := CreateKey(rw, rootHandle, pcrSelection7, emptyPassword, emptyPassword, defaultKeyParams)
+	quotePrivate, quotePublic, _, _, _, err := CreateKey(rw, rootHandle, pcrSelection7, emptyPassword, emptyPassword, defaultKeyParams)
 	if err != nil {
 		t.Fatalf("CreateKey failed: %v", err)
 	}
@@ -347,7 +347,7 @@ func TestEvictControl(t *testing.T) {
 	defer FlushContext(rw, rootHandle)
 
 	// CreateKey (Quote Key)
-	_, quotePrivate, quotePublic, _, _, _, err := CreateKey(rw, rootHandle, pcrSelection7, emptyPassword, emptyPassword, defaultKeyParams)
+	quotePrivate, quotePublic, _, _, _, err := CreateKey(rw, rootHandle, pcrSelection7, emptyPassword, emptyPassword, defaultKeyParams)
 	if err != nil {
 		t.Fatalf("CreateKey failed: %v", err)
 	}
@@ -1229,7 +1229,7 @@ func TestEncryptDecrypt(t *testing.T) {
 		t.Fatalf("CreatePrimary failed: %s", err)
 	}
 	defer FlushContext(rw, parentHandle)
-	_, privateBlob, publicBlob, _, _, _, err := CreateKey(rw, parentHandle, pcrSelection7, defaultPassword, defaultPassword, Public{
+	privateBlob, publicBlob, _, _, _, err := CreateKey(rw, parentHandle, pcrSelection7, defaultPassword, defaultPassword, Public{
 		Type:       AlgSymCipher,
 		NameAlg:    AlgSHA256,
 		Attributes: FlagDecrypt | FlagSign | FlagUserWithAuth | FlagFixedParent | FlagFixedTPM | FlagSensitiveDataOrigin,


### PR DESCRIPTION
Fixes #102

[Part 3 of the Spec](https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-3-Commands-01.38-code.pdf) (sections 4.2.1 and 4.3) describe how, when a command uses Authorization Tags, there is an additional UINT32 `paramSize` in the response, between the handles and parameters. We usually properly deal with this parameter, but not always.

This [spreadsheet of TPM2 commands](https://docs.google.com/spreadsheets/d/1WfZCb1G7wK0tZetN51lI7bPWbazSY3m5AlUYIzRjhK0/edit?usp=sharing) lists all the TPM2 commands (including if they should have authorization sessions). We only care about commands where:
  - An authorization session is required
  - We care about the return parameters (otherwise we won't even bother decoding the response).

The only commands we were messing up were TPM2_Create and TPM2_PolicySecret. These are now fixed.

EDIT: Note that the changes to `Create` are backwards incompatible, so incrementing the version will be required. 