### PR TITLE
Support KeyedHashUnique, other structure cleanup

### DIFF
--- a/tpm2/credactivation/credential_activation.go
+++ b/tpm2/credactivation/credential_activation.go
@@ -121,14 +121,19 @@ func generateRSA(aik *tpm2.HashValue, pub *rsa.PublicKey, symBlockSize int, secr
 		IntegrityHMAC: integrityHMAC,
 		EncIdentity:   encIdentity,
 	}
-	id, err := idObject.Encode()
+	id, err := tpmutil.Pack(idObject)
 	if err != nil {
 		return nil, nil, fmt.Errorf("encoding IDObject: %v", err)
+	}
+
+	packedID, err := tpmutil.Pack(tpmutil.U16Bytes(id))
+	if err != nil {
+		return nil, nil, fmt.Errorf("packing id: %v", err)
 	}
 	packedEncSecret, err := tpmutil.Pack(tpmutil.U16Bytes(encSecret))
 	if err != nil {
 		return nil, nil, fmt.Errorf("packing encSecret: %v", err)
 	}
 
-	return id, packedEncSecret, nil
+	return packedID, packedEncSecret, nil
 }


### PR DESCRIPTION
This PR makes a bunch of minor changes to various TPM2 structures.

- Adds `Public.Name()` which computes the name of a specific Public Area.
  - Useful for server-side computations (i.e. for Import, ActivateCredential, and the KDF)
  - `Name.MatchesPublic` now has a trivial implementation
- Support `KeyedHashUnique` field in `Public` structure
  - This allows for Keyed Hash objects to be used with `ReadPublic` and `CreatePrimary`
  - Also allows for easier computation of names for TPM2_Import
- Fix encoding of `IDObject`
  - The default `tpmutil.Pack` encoding will work, except that the additional `tpmutil.Pack` operation should be done in the `generateRSA` function, not in the encoding function.
  - Allows for use of inner wrappers with TPM2_Import