### PR TITLE
Name() should not return a pointer

### DIFF
--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -118,18 +118,18 @@ func (p Public) Key() (crypto.PublicKey, error) {
 }
 
 // Name computes the Digest-based Name from the public area of an object.
-func (p Public) Name() (*Name, error) {
+func (p Public) Name() (Name, error) {
 	pubEncoded, err := p.Encode()
 	if err != nil {
-		return nil, err
+		return Name{}, err
 	}
 	hash, err := p.NameAlg.HashConstructor()
 	if err != nil {
-		return nil, err
+		return Name{}, err
 	}
 	nameHash := hash()
 	nameHash.Write(pubEncoded)
-	return &Name{
+	return Name{
 		Digest: &HashValue{
 			Alg:   p.NameAlg,
 			Value: nameHash.Sum(nil),


### PR DESCRIPTION
Something I missed in #112, `tpm2.Name` is generally used as a value, not a pointer. `Public.Name` should be consistent in this fact.