### PR TITLE
Add Public.MatchesTemplate

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -64,8 +64,10 @@ const (
 	AlgUnknown   Algorithm = 0x0000
 	AlgRSA       Algorithm = 0x0001
 	AlgSHA1      Algorithm = 0x0004
+	AlgHMAC      Algorithm = 0x0005
 	AlgAES       Algorithm = 0x0006
 	AlgKeyedHash Algorithm = 0x0008
+	AlgXOR       Algorithm = 0x000A
 	AlgSHA256    Algorithm = 0x000B
 	AlgSHA384    Algorithm = 0x000C
 	AlgSHA512    Algorithm = 0x000D

--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -61,12 +61,12 @@ type Public struct {
 	Attributes KeyProp
 	AuthPolicy tpmutil.U16Bytes
 
-	// Only one of the following fields should be set. When encoding/decoding,
-	// one will be picked based on Type.
+	// Exactly one of the following fields should be set
+	// When encoding/decoding, one will be picked based on Type.
 	RSAParameters       *RSAParams
 	ECCParameters       *ECCParams
 	SymCipherParameters *SymCipherParams
-	KeyedHashParameters *KeyedHashParams // Optional for AlgKeyedHash
+	KeyedHashParameters *KeyedHashParams
 }
 
 // Encode serializes a Public structure in TPM wire format.

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -1433,9 +1433,12 @@ func TestMatchesTemplate(t *testing.T) {
 					Type:       AlgKeyedHash,
 					NameAlg:    AlgSHA256,
 					Attributes: FlagSignerDefault,
+					KeyedHashParameters: &KeyedHashParams{
+						Alg: AlgNull,
+					},
 				}
 			},
-			func(pub *Public) { pub.KeyedHashUnique = make([]byte, 256) },
+			func(pub *Public) { pub.KeyedHashParameters.Unique = make([]byte, 256) },
 			func(pub *Public) { pub.Attributes |= FlagNoDA },
 		},
 	}

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -1365,13 +1365,14 @@ func TestCreatePrimaryRawTemplate(t *testing.T) {
 }
 
 func TestMatchesTemplate(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name       string
 		makePublic func() Public
 		goodChange func(*Public)
 		badChange  func(*Public)
 	}{
-		{"RSA",
+		{
+			"RSA",
 			func() Public {
 				return Public{
 					Type:       AlgRSA,
@@ -1382,16 +1383,16 @@ func TestMatchesTemplate(t *testing.T) {
 							Alg:  AlgRSASSA,
 							Hash: AlgSHA256,
 						},
-						KeyBits:  2048,
-						Exponent: 0,
-						Modulus:  big.NewInt(0),
+						KeyBits: 2048,
+						Modulus: big.NewInt(0),
 					},
 				}
 			},
 			func(pub *Public) { pub.RSAParameters.Modulus = big.NewInt(15) },
 			func(pub *Public) { pub.RSAParameters.KeyBits = 1024 },
 		},
-		{"ECC",
+		{
+			"ECC",
 			func() Public {
 				return Public{
 					Type:       AlgECC,
@@ -1409,7 +1410,8 @@ func TestMatchesTemplate(t *testing.T) {
 			func(pub *Public) { pub.ECCParameters.Point.X = big.NewInt(15) },
 			func(pub *Public) { pub.ECCParameters.CurveID = CurveNISTP384 },
 		},
-		{"SymCipher",
+		{
+			"SymCipher",
 			func() Public {
 				return Public{
 					Type:       AlgSymCipher,
@@ -1427,19 +1429,34 @@ func TestMatchesTemplate(t *testing.T) {
 			func(pub *Public) { pub.SymCipherParameters.Unique = make([]byte, 256) },
 			func(pub *Public) { pub.SymCipherParameters.Symmetric.KeyBits = 256 },
 		},
-		{"KeyedHash",
+		{
+			"KeyedHash",
 			func() Public {
 				return Public{
 					Type:       AlgKeyedHash,
 					NameAlg:    AlgSHA256,
 					Attributes: FlagSignerDefault,
 					KeyedHashParameters: &KeyedHashParams{
-						Alg: AlgNull,
+						Alg:  AlgHMAC,
+						Hash: AlgSHA256,
 					},
 				}
 			},
 			func(pub *Public) { pub.KeyedHashParameters.Unique = make([]byte, 256) },
-			func(pub *Public) { pub.Attributes |= FlagNoDA },
+			func(pub *Public) { pub.KeyedHashParameters.Hash = AlgSHA1 },
+		},
+		{
+			"TypeMismatch",
+			func() Public {
+				return Public{
+					Type:                AlgKeyedHash,
+					NameAlg:             AlgSHA256,
+					Attributes:          FlagSignerDefault,
+					KeyedHashParameters: &KeyedHashParams{Alg: AlgNull},
+				}
+			},
+			func(pub *Public) { pub.KeyedHashParameters.Unique = make([]byte, 256) },
+			func(pub *Public) { pub.Type = AlgRSA },
 		},
 	}
 


### PR DESCRIPTION
For example, this makes it easier to check if a persistent handle is the cached version of a key we want to create, allowing us to write something like:

```go
func getKey(template Public, cached Handle) Handle {
    pub, _, _, err := ReadPublic(rw, cached)
    if err == nil && pub.MatchesTemplate(template) {
        return cached
    }
    return CreatePrimary(rw, ... , template)
}
```