### PR TITLE
Fix test build failures

### DIFF
--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -1406,7 +1406,7 @@ func TestMatchesTemplate(t *testing.T) {
 					},
 				}
 			},
-			func(pub *Public) { pub.ECCParameters.Point.X = big.NewInt(15) },
+			func(pub *Public) { pub.ECCParameters.Point.XRaw = make([]byte, 32) },
 			func(pub *Public) { pub.ECCParameters.CurveID = CurveNISTP384 },
 		},
 		{


### PR DESCRIPTION
Merging #117 and #118 caused tests to stop building, now fixed.