### PR TITLE
Use ExponentRaw and ModulusRaw

### DIFF
--- a/examples/tpm2-ekcert/main.go
+++ b/examples/tpm2-ekcert/main.go
@@ -47,7 +47,6 @@ var (
 				Mode:    tpm2.AlgCFB,
 			},
 			KeyBits:    2048,
-			Exponent:   0,
 			ModulusRaw: make([]byte, 256),
 		},
 	}

--- a/examples/tpm2-seal-unseal/main.go
+++ b/examples/tpm2-seal-unseal/main.go
@@ -44,7 +44,6 @@ var (
 				Mode:    tpm2.AlgCFB,
 			},
 			KeyBits:    2048,
-			Exponent:   0,
 			ModulusRaw: make([]byte, 256),
 		},
 	}

--- a/tpm2/benchmark_test.go
+++ b/tpm2/benchmark_test.go
@@ -16,7 +16,6 @@ package tpm2
 
 import (
 	"crypto/sha256"
-	"math/big"
 	"testing"
 )
 
@@ -34,8 +33,7 @@ func BenchmarkRSA2048Signing(b *testing.B) {
 				Alg:  AlgRSASSA,
 				Hash: AlgSHA256,
 			},
-			KeyBits: uint16(2048),
-			Modulus: big.NewInt(0),
+			KeyBits: 2048,
 		},
 	}
 

--- a/tpm2/encoding_test.go
+++ b/tpm2/encoding_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/hex"
-	"math/big"
 	"reflect"
 	"testing"
 
@@ -142,9 +141,8 @@ func TestEncodeCreate(t *testing.T) {
 				KeyBits: 128,
 				Mode:    AlgCFB,
 			},
-			KeyBits:  1024,
-			Exponent: uint32(0x00010001),
-			Modulus:  big.NewInt(0),
+			KeyBits:     1024,
+			ExponentRaw: 0x00010001,
 		},
 	}
 	auth := AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession}

--- a/tpm2/encoding_test.go
+++ b/tpm2/encoding_test.go
@@ -134,7 +134,7 @@ func TestEncodeCreate(t *testing.T) {
 	params := Public{
 		Type:       AlgRSA,
 		NameAlg:    AlgSHA1,
-		Attributes: 0x00030072,
+		Attributes: FlagStorageDefault,
 		RSAParameters: &RSAParams{
 			Symmetric: &SymScheme{
 				Alg:     AlgAES,
@@ -142,7 +142,7 @@ func TestEncodeCreate(t *testing.T) {
 				Mode:    AlgCFB,
 			},
 			KeyBits:     1024,
-			ExponentRaw: 0x00010001,
+			ExponentRaw: defaultRSAExponent,
 		},
 	}
 	auth := AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession}

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -83,7 +83,7 @@ var (
 	defaultKeyParams = Public{
 		Type:       AlgRSA,
 		NameAlg:    AlgSHA1,
-		Attributes: 0x00030072,
+		Attributes: FlagStorageDefault,
 		RSAParameters: &RSAParams{
 			Symmetric: &SymScheme{
 				Alg:     AlgAES,
@@ -91,7 +91,7 @@ var (
 				Mode:    AlgCFB,
 			},
 			KeyBits:     2048,
-			ExponentRaw: 0x00010001,
+			ExponentRaw: defaultRSAExponent,
 		},
 	}
 	defaultPassword = "\x01\x02\x03\x04"


### PR DESCRIPTION
Similar to #118, this PR updates `RSAParams` to have `ExponentRaw` and `ModulusRaw` parameters, instead of the four `encodeDefaultExponentAsZero`, `Exponent`, `Modulus`, and `ModulusRaw` parameters.

This allows for simpler encoding/decoding as well as a more clear API. It makes a much clearer distinction between parameters are actually encoded, and the values the represent.

EDIT: For the RSA exponent specifically, `ExponentRaw` is essentially what `encodedExponent()` was before, and the `Exponent()` method is what the `Exponent` field was before.

Before, if the binary data had an Exponent of `0`, we set `encodeDefaultExponentAsZero` to `true` and `Exponent` to `defaultRSAExponent` when decoding. Now, `ExponentRaw` just stays as 0, there is no `encodeDefaultExponentAsZero`, and the `Exponent()` method returns `defaultRSAExponent`. Reencoding is then also straighforward and correct, as verified by the tests.

Corresponding tests and examples are also updated. 