### PR TITLE
Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,13 @@
+container:
+  dockerfile: Dockerfile
+
+env:
+  GOPROXY: https://proxy.golang.org
+  GO111MODULE: on
+
+test_task:
+  modules_cache:
+    fingerprint_script: cat go.sum
+    folder: $GOPATH/pkg/mod
+  build_script: go build -v ./...
+  test_script: go test -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM golang:latest
 # We need OpenSSL headers to build the simulator
-RUN apt-get update && apt-get install -y libssl-dev
+RUN apt-get update && apt-get install -y \
+    libssl-dev \
+ && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:latest
+# We need OpenSSL headers to build the simulator
+RUN apt-get update && apt-get install -y libssl-dev


### PR DESCRIPTION
Configuration is much easier, and we avoid needing internal CI
configuration. Files based on those in https://github.com/google/go-tpm-tools/pull/39

EDIT: it looks like Cirrus didn't get properly installed, so this isn't working yet. We will have to wait on the admin to enable.