### PR TITLE
Add SignWithSession

### DIFF
--- a/tpm2/encoding_test.go
+++ b/tpm2/encoding_test.go
@@ -450,7 +450,7 @@ func TestSignEncode(t *testing.T) {
 			t.Fatal(err)
 		}
 		digest := []byte{0x01, 0x02, 0x03}
-		cmdBytes, err := encodeSign(tpmutil.Handle(0x80000001), defaultPassword, digest, nil)
+		cmdBytes, err := encodeSign(HandlePasswordSession, tpmutil.Handle(0x80000001), defaultPassword, digest, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -465,7 +465,7 @@ func TestSignEncode(t *testing.T) {
 			t.Fatal(err)
 		}
 		digest := []byte{0x01, 0x02, 0x03}
-		cmdBytes, err := encodeSign(tpmutil.Handle(0x80000001), defaultPassword, digest, &SigScheme{
+		cmdBytes, err := encodeSign(HandlePasswordSession, tpmutil.Handle(0x80000001), defaultPassword, digest, &SigScheme{
 			Alg:  AlgRSASSA,
 			Hash: AlgSHA256,
 		})

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1328,7 +1328,7 @@ func decodeSign(buf []byte) (*Signature, error) {
 }
 
 // SignWithSession computes a signature for digest using a given loaded key. Signature
-// algorithm depends on the key type. Used for keys with non-default authorization policies.
+// algorithm depends on the key type. Used for keys with non-password authorization policies.
 func SignWithSession(rw io.ReadWriter, sessionHandle, key tpmutil.Handle, password string, digest []byte, sigScheme *SigScheme) (*Signature, error) {
 	cmd, err := encodeSign(sessionHandle, key, password, digest, sigScheme)
 	if err != nil {

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1328,7 +1328,7 @@ func decodeSign(buf []byte) (*Signature, error) {
 }
 
 // SignWithSession computes a signature for digest using a given loaded key. Signature
-// algorithm depends on the key type.
+// algorithm depends on the key type. Used for keys with non-default authorization policies.
 func SignWithSession(rw io.ReadWriter, sessionHandle, key tpmutil.Handle, password string, digest []byte, sigScheme *SigScheme) (*Signature, error) {
 	cmd, err := encodeSign(sessionHandle, key, password, digest, sigScheme)
 	if err != nil {


### PR DESCRIPTION
SignWithSession is needed to support Signing Keys with a PCR policy.  