### PR TITLE
Check attested data has TPMS_GENERATED_VALUE

### DIFF
--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -645,6 +645,13 @@ func DecodeAttestationData(in []byte) (*AttestationData, error) {
 	if err := tpmutil.UnpackBuf(buf, &ad.Magic, &ad.Type); err != nil {
 		return nil, fmt.Errorf("decoding Magic/Type: %v", err)
 	}
+	// All attestation structures have the magic prefix
+	// TPMS_GENERATED_VALUE to symbolize they were created by
+	// the TPM when signed with an AK.
+	if ad.Magic != 0xff544347 {
+		return nil, fmt.Errorf("incorrect magic value: %x", ad.Magic)
+	}
+
 	n, err := DecodeName(buf)
 	if err != nil {
 		return nil, fmt.Errorf("decoding QualifiedSigner: %v", err)

--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -773,7 +773,7 @@ func TestReadPCR(t *testing.T) {
 func makeAttestationData() AttestationData {
 	signer := tpmutil.Handle(100)
 	return AttestationData{
-		Magic: 1,
+		Magic: 0xff544347,
 		QualifiedSigner: Name{
 			Handle: &signer,
 		},


### PR DESCRIPTION
This is kinda important ... but I only just noticed.

Without this check, a fake (but valid in the context of go-tpm's decode method) attestation blob could be generated that the TPM AK would sign.