### PR TITLE
Add QuoteRaw() in tpm2

### DIFF
--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -909,12 +909,15 @@ func encodeQuote(signingHandle tpmutil.Handle, parentPassword, ownerPassword str
 func decodeQuote(in []byte) ([]byte, []byte, error) {
 	buf := bytes.NewBuffer(in)
 	var paramSize uint32
-	var attest tpmutil.U16Bytes
-	if err := tpmutil.UnpackBuf(buf, &paramSize, &attest); err != nil {
+	if err := tpmutil.UnpackBuf(buf, &paramSize); err != nil {
 		return nil, nil, err
 	}
-	rawSig := buf.Next(int(paramSize) - len(attest))
-	return attest, rawSig, nil
+	buf.Truncate(int(paramSize))
+	var attest tpmutil.U16Bytes
+	if err := tpmutil.UnpackBuf(buf, &attest); err != nil {
+		return nil, nil, err
+	}
+	return attest, buf.Bytes(), nil
 }
 
 // Quote returns a quote of PCR values. A quote is a signature of the PCR


### PR DESCRIPTION
Add a new QuoteRawSignature() function in tpm2, which is very similar to Quote() except that it will return the Signature part as a raw byte array. This will allow to save the signature in a protobuf without Encoding the signature again. 

This will be used in google/go-tpm-tools#53