### PR TITLE
Add Hash() to tpm2.Algorithm which will return crypto.Hash

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -17,14 +17,22 @@ package tpm2
 import (
 	"crypto"
 	"crypto/elliptic"
-	"crypto/sha1"
-	"crypto/sha256"
-	"crypto/sha512"
 	"fmt"
-	"hash"
+
+	// register hash algorithm
+	_ "crypto/sha1"
+	_ "crypto/sha256"
+	_ "crypto/sha512"
 
 	"github.com/google/go-tpm/tpmutil"
 )
+
+var hashMapping = map[Algorithm]crypto.Hash{
+	AlgSHA1:   crypto.SHA1,
+	AlgSHA256: crypto.SHA256,
+	AlgSHA384: crypto.SHA384,
+	AlgSHA512: crypto.SHA512,
+}
 
 // MAX_DIGEST_BUFFER is the maximum size of []byte request or response fields.
 // Typically used for chunking of big blobs of data (such as for hashing or
@@ -49,23 +57,15 @@ func (a Algorithm) UsesHash() bool {
 	return a == AlgOAEP
 }
 
-// HashConstructor returns a function that can be used to make a
-// hash.Hash using the specified algorithm. An error is returned
-// if the algorithm is not a hash algorithm.
-func (a Algorithm) HashConstructor() (func() hash.Hash, error) {
-	c, ok := hashConstructors[a]
-	if !ok {
-		return nil, fmt.Errorf("algorithm not supported: 0x%x", a)
-	}
-	return c, nil
-}
-
-// HashMapping returns a crypto.Hash based on the given TPM_ALG_ID.
-// An error is returned if the given algorithm is not a hash algorithm.
-func (a Algorithm) HashMapping() (crypto.Hash, error) {
+// Hash returns a crypto.Hash based on the given TPM_ALG_ID.
+// An error is returned if the given algorithm is not a hash algorithm or is not available.
+func (a Algorithm) Hash() (crypto.Hash, error) {
 	hash, ok := hashMapping[a]
 	if !ok {
-		return crypto.Hash(0), fmt.Errorf("algorithm not supported: 0x%x", a)
+		return crypto.Hash(0), fmt.Errorf("hash algorithm not supported: 0x%x", a)
+	}
+	if !hash.Available() {
+		return crypto.Hash(0), fmt.Errorf("go hash algorithm #%d not available", hash)
 	}
 	return hash, nil
 }
@@ -367,36 +367,7 @@ const (
 // Regular TPM 2.0 devices use 24-bit mask (3 bytes) for PCR selection.
 const sizeOfPCRSelect = 3
 
-// digestSize returns the size of a digest for hashing algorithm alg, or 0 if
-// it's not recognized.
-func digestSize(alg Algorithm) int {
-	switch alg {
-	case AlgSHA1:
-		return sha1.Size
-	case AlgSHA256:
-		return sha256.Size
-	case AlgSHA512:
-		return sha512.Size
-	default:
-		return 0
-	}
-}
-
 const defaultRSAExponent = 1<<16 + 1
-
-var hashConstructors = map[Algorithm]func() hash.Hash{
-	AlgSHA1:   sha1.New,
-	AlgSHA256: sha256.New,
-	AlgSHA384: sha512.New384,
-	AlgSHA512: sha512.New,
-}
-
-var hashMapping = map[Algorithm]crypto.Hash{
-	AlgSHA1:   crypto.SHA1,
-	AlgSHA256: crypto.SHA256,
-	AlgSHA384: crypto.SHA384,
-	AlgSHA512: crypto.SHA512,
-}
 
 // NVAttr is a bitmask used in Attributes field of NV indexes. Individual
 // flags should be OR-ed to form a full mask.

--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -15,6 +15,7 @@
 package tpm2
 
 import (
+	"crypto"
 	"crypto/elliptic"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -57,6 +58,16 @@ func (a Algorithm) HashConstructor() (func() hash.Hash, error) {
 		return nil, fmt.Errorf("algorithm not supported: 0x%x", a)
 	}
 	return c, nil
+}
+
+// HashMapping returns a crypto.Hash based on the given TPM_ALG_ID.
+// An error is returned if the given algorithm is not a hash algorithm.
+func (a Algorithm) HashMapping() (crypto.Hash, error) {
+	hash, ok := hashMapping[a]
+	if !ok {
+		return crypto.Hash(0), fmt.Errorf("algorithm not supported: 0x%x", a)
+	}
+	return hash, nil
 }
 
 // Supported Algorithms.
@@ -378,6 +389,13 @@ var hashConstructors = map[Algorithm]func() hash.Hash{
 	AlgSHA256: sha256.New,
 	AlgSHA384: sha512.New384,
 	AlgSHA512: sha512.New,
+}
+
+var hashMapping = map[Algorithm]crypto.Hash{
+	AlgSHA1:   crypto.SHA1,
+	AlgSHA256: crypto.SHA256,
+	AlgSHA384: crypto.SHA384,
+	AlgSHA512: crypto.SHA512,
 }
 
 // NVAttr is a bitmask used in Attributes field of NV indexes. Individual

--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -19,7 +19,7 @@ import (
 	"crypto/elliptic"
 	"fmt"
 
-	// register hash algorithm
+	// Register the relevant hash implementations to prevent a runtime failure.
 	_ "crypto/sha1"
 	_ "crypto/sha256"
 	_ "crypto/sha512"

--- a/tpm2/kdf.go
+++ b/tpm2/kdf.go
@@ -27,11 +27,11 @@ import (
 // The label parameter is a non-null-terminated string.
 // The contextU & contextV parameters are optional.
 func KDFa(hashAlg Algorithm, key []byte, label string, contextU, contextV []byte, bits int) ([]byte, error) {
-	h, err := hashAlg.HashConstructor()
+	h, err := hashAlg.Hash()
 	if err != nil {
 		return nil, err
 	}
-	mac := hmac.New(h, key)
+	mac := hmac.New(h.New, key)
 
 	out := kdf(mac, bits, func() {
 		mac.Write([]byte(label))
@@ -50,11 +50,11 @@ func KDFa(hashAlg Algorithm, key []byte, label string, contextU, contextV []byte
 // The use parameter is a non-null-terminated string.
 // The partyUInfo and partyVInfo are the x coordinates of the initiators and the responders ECC points respectively.
 func KDFe(hashAlg Algorithm, z []byte, use string, partyUInfo, partyVInfo []byte, bits int) ([]byte, error) {
-	createHash, err := hashAlg.HashConstructor()
+	createHash, err := hashAlg.Hash()
 	if err != nil {
 		return nil, err
 	}
-	h := createHash()
+	h := createHash.New()
 
 	out := kdf(h, bits, func() {
 		h.Write(z)

--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -124,11 +124,11 @@ func (p Public) Name() (Name, error) {
 	if err != nil {
 		return Name{}, err
 	}
-	hash, err := p.NameAlg.HashConstructor()
+	hash, err := p.NameAlg.Hash()
 	if err != nil {
 		return Name{}, err
 	}
-	nameHash := hash()
+	nameHash := hash.New()
 	nameHash.Write(pubEncoded)
 	return Name{
 		Digest: &HashValue{
@@ -965,11 +965,11 @@ func decodeHashValue(in *bytes.Buffer) (*HashValue, error) {
 	if err := tpmutil.UnpackBuf(in, &hv.Alg); err != nil {
 		return nil, fmt.Errorf("decoding Alg: %v", err)
 	}
-	hfn, ok := hashConstructors[hv.Alg]
+	hfn, ok := hashMapping[hv.Alg]
 	if !ok {
 		return nil, fmt.Errorf("unsupported hash algorithm type 0x%x", hv.Alg)
 	}
-	hv.Value = make(tpmutil.U16Bytes, hfn().Size())
+	hv.Value = make(tpmutil.U16Bytes, hfn.Size())
 	if _, err := in.Read(hv.Value); err != nil {
 		return nil, fmt.Errorf("decoding Value: %v", err)
 	}

--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -967,7 +967,7 @@ func decodeHashValue(in *bytes.Buffer) (*HashValue, error) {
 	}
 	hfn, ok := hashMapping[hv.Alg]
 	if !ok {
-		return nil, fmt.Errorf("unsupported hash algorithm type 0x%x", hv.Alg)
+		return nil, fmt.Errorf("hash algorithm not supported: 0x%x", hv.Alg)
 	}
 	hv.Value = make(tpmutil.U16Bytes, hfn.Size())
 	if _, err := in.Read(hv.Value); err != nil {


### PR DESCRIPTION
In some cases, I want to have a mapping between the hashalgo in tpm2 and crypto package. So I can easily reference to a crypto hashAlgo from a tpm2 Algo.

Currently using HashConstructor, we can get hash.Hash interface from a tpm2.Algorithm. But we couldn't get crypto.Hash from hash.Hash or tpm2.Algorithm

We need something similar to the go-attestation here in go-tpm so everyone can use it:
https://github.com/google/go-attestation/blob/25ce56400c9ff0a90a3f8b3eb47bf1698fe9319a/attest/tpm.go#L102b