### PR TITLE
Fix tpmtool.poll function to build on arm64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/google/go-tpm
 
 go 1.12
 
-require github.com/google/go-tpm-tools v0.0.0-20190906225433-1614c142f845
+require (
+	github.com/google/go-tpm-tools v0.0.0-20190906225433-1614c142f845
+	golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a
+)

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a h1:1n5lsVfiQW3yfsRGu98756EH1YthsFqr/5mxHduZW2A=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/tpmutil/poll_unix.go
+++ b/tpmutil/poll_unix.go
@@ -5,38 +5,29 @@ package tpmutil
 import (
 	"fmt"
 	"os"
-	"syscall"
-	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
-type pollFD struct {
-	fd      int32
-	events  int16
-	revents int16
-}
-
-// poll blocks until the file descriptior is ready for reading or an error occurs.
+// poll blocks until the file descriptor is ready for reading or an error occurs.
 func poll(f *os.File) error {
 	var (
-		fd = &pollFD{
-			fd:     int32(f.Fd()),
-			events: 0x1, // POLLIN
-		}
-		numFD     = 1
-		timeoutMS = -1 // Do not set a timeout
+		fds = []unix.PollFd{{
+			Fd:     int32(f.Fd()),
+			Events: 0x1, // POLLIN
+		}}
+		timeout = 0 // No timeout
 	)
-	_, _, errno := syscall.Syscall(syscall.SYS_POLL, uintptr(unsafe.Pointer(fd)), uintptr(numFD), uintptr(timeoutMS))
-	// Convert errno into an error, otherwise err != nil checks up the stack
-	// will hit unexpectedly on 0 errno.
-	var err error
-	if errno != 0 {
-		err = errno
+
+	_, err := unix.Poll(fds, timeout)
+	if err != nil {
 		return err
 	}
-	// revents is filled in by the kernel.
-	// If the expected event happened, revents should match events.
-	if fd.revents != fd.events {
-		return fmt.Errorf("unexpected poll revents 0x%x", fd.revents)
+
+	// Revents is filled in by the kernel.
+	// If the expected event happened, Revents should match events.
+	if fds[0].Revents != fds[0].Events {
+		return fmt.Errorf("unexpected poll Revents 0x%x", fds[0].Revents)
 	}
 	return nil
 }

--- a/tpmutil/poll_unix.go
+++ b/tpmutil/poll_unix.go
@@ -19,13 +19,12 @@ func poll(f *os.File) error {
 		timeout = 0 // No timeout
 	)
 
-	_, err := unix.Poll(fds, timeout)
-	if err != nil {
+	if _, err := unix.Poll(fds, timeout); err != nil {
 		return err
 	}
 
 	// Revents is filled in by the kernel.
-	// If the expected event happened, Revents should match events.
+	// If the expected event happened, Revents should match Events.
 	if fds[0].Revents != fds[0].Events {
 		return fmt.Errorf("unexpected poll Revents 0x%x", fds[0].Revents)
 	}


### PR DESCRIPTION
To achieve this, the underlying syscall is changed from poll to ppoll.
When timeout and sigmask are null, the behaviour of poll and ppoll are
equivalent (according to the man page).

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>

Fixes #146