### PR TITLE
Fix decodeCertify() unpack buf

### DIFF
--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1395,8 +1395,23 @@ func decodeCertify(resp []byte) ([]byte, []byte, error) {
 	var paramSize uint32
 	var attest, signature tpmutil.U16Bytes
 	var sigAlg, hashAlg Algorithm
-	if _, err := tpmutil.Unpack(resp, &paramSize, &attest, &sigAlg, &hashAlg, &signature); err != nil {
+
+	buf := bytes.NewBuffer(resp)
+	if err := tpmutil.UnpackBuf(buf, &paramSize); err != nil {
 		return nil, nil, err
+	}
+	buf.Truncate(int(paramSize))
+	if err := tpmutil.UnpackBuf(buf, &attest, &sigAlg); err != nil {
+		return nil, nil, err
+	}
+	// If sigAlg is AlgNull, there will be no hashAlg or signature.
+	// This will happen if AlgNull was passed in the Certify() as
+	// the signing key (no need to sign the response).
+	// See TPM2 spec part4 pg227 SignAttestInfo()
+	if sigAlg != AlgNull {
+		if err := tpmutil.UnpackBuf(buf, &hashAlg, &signature); err != nil {
+			return nil, nil, err
+		}
 	}
 	return attest, signature, nil
 }


### PR DESCRIPTION
Current decodeCertify() will unpack the buf regardless what sigAlg it is.
This works fine if sigAlg is not AlgNull.

But sigAlg can be AlgNull, in which case hashAlg or signature will not exist. And unpack these 2 values will cause the program to throw exception.

The sigAlg could be AlgNull because CertifyCreate() or Certify() can pass in HandleNull as the signer handle. (which means don't need to sign the response)