### PR TITLE
add CreateKeyWithSensitive() in tpm2

### DIFF
--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -897,15 +897,14 @@ func TestCreateKeyWithSensitive(t *testing.T) {
 	}
 	defer FlushContext(rw, parentHandle)
 
-	secret := []byte("test_secret")
 	_, _, _, _, _, err = CreateKeyWithSensitive(rw, parentHandle, pcrSelection7, defaultPassword, defaultPassword, Public{
 		Type:       AlgKeyedHash,
 		NameAlg:    AlgSHA256,
 		Attributes: FlagFixedTPM | FlagFixedParent,
 		AuthPolicy: nil,
-	}, secret)
+	}, []byte("test_secret"))
 	if err != nil {
-		t.Fatalf("CreateKeyWithSensitive failed: %s", err)
+		t.Errorf("CreateKeyWithSensitive failed: %s", err)
 	}
 }
 

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -560,9 +560,9 @@ func CreateKeyUsingAuth(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection
 	return create(rw, owner, auth, ownerPassword, nil /*inSensitive*/, pub, sel)
 }
 
-// CreateWithSensitive is very similar to CreateKey, except
+// CreateKeyWithSensitive is very similar to CreateKey, except
 // that it can take in a piece of sensitive data.
-func CreateWithSensitive(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection, parentPassword, ownerPassword string, pub Public, sensitive []byte) (private, public, creationData, creationHash []byte, creationTicket Ticket, err error) {
+func CreateKeyWithSensitive(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection, parentPassword, ownerPassword string, pub Public, sensitive []byte) (private, public, creationData, creationHash []byte, creationTicket Ticket, err error) {
 	auth := AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(parentPassword)}
 	return create(rw, owner, auth, ownerPassword, sensitive, pub, sel)
 }

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -560,6 +560,13 @@ func CreateKeyUsingAuth(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection
 	return create(rw, owner, auth, ownerPassword, nil /*inSensitive*/, pub, sel)
 }
 
+// CreateWithSensitive is very similar to CreateKey, except
+// that it can take in a piece of sensitive data.
+func CreateWithSensitive(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection, parentPassword, ownerPassword string, pub Public, sensitive []byte) (private, public, creationData, creationHash []byte, creationTicket Ticket, err error) {
+	auth := AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(parentPassword)}
+	return create(rw, owner, auth, ownerPassword, sensitive, pub, sel)
+}
+
 // Seal creates a data blob object that seals the sensitive data under a parent and with a
 // password and auth policy. Access to the parent must be available with a simple password.
 // Returns private and public portions of the created object.


### PR DESCRIPTION
Currently, all exported Create*() functions don't support creating with "sensitive" data. Added a function to allow user to create with "sensitive" data.