### PR TITLE
Remove decodeTicket(), change a few function to accept/return Ticket instead of *Ticket

### DIFF
--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -1012,14 +1012,6 @@ type Ticket struct {
 	Digest    tpmutil.U16Bytes
 }
 
-func decodeTicket(in *bytes.Buffer) (*Ticket, error) {
-	var t Ticket
-	if err := tpmutil.UnpackBuf(in, &t.Type, &t.Hierarchy, &t.Digest); err != nil {
-		return nil, fmt.Errorf("decoding Type, Hierarchy, Digest: %v", err)
-	}
-	return &t, nil
-}
-
 // AuthCommand represents a TPMS_AUTH_COMMAND. This structure encapsulates parameters
 // which authorize the use of a given handle or parameter.
 type AuthCommand struct {

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -421,12 +421,8 @@ func decodeCreatePrimary(in []byte) (handle tpmutil.Handle, public, creationData
 		return 0, nil, nil, nil, Ticket{}, nil, fmt.Errorf("decoding handle, paramSize: %v", err)
 	}
 
-	if err := tpmutil.UnpackBuf(buf, &public, &creationData, &creationHash, &ticket); err != nil {
-		return 0, nil, nil, nil, Ticket{}, nil, fmt.Errorf("decoding public, creationData, creationHash, ticket: %v", err)
-	}
-
-	if err := tpmutil.UnpackBuf(buf, &creationName); err != nil {
-		return 0, nil, nil, nil, Ticket{}, nil, fmt.Errorf("decoding creationName: %v", err)
+	if err := tpmutil.UnpackBuf(buf, &public, &creationData, &creationHash, &ticket, &creationName); err != nil {
+		return 0, nil, nil, nil, Ticket{}, nil, fmt.Errorf("decoding public, creationData, creationHash, ticket, creationName: %v", err)
 	}
 
 	if _, err := DecodeCreationData(creationData); err != nil {
@@ -741,11 +737,11 @@ func decodePolicySecret(in []byte) (*Ticket, error) {
 	if err := tpmutil.UnpackBuf(buf, &paramSize, &timeout); err != nil {
 		return nil, fmt.Errorf("decoding timeout: %v", err)
 	}
-	var t *Ticket
-	if err := tpmutil.UnpackBuf(buf, t); err != nil {
+	var t Ticket
+	if err := tpmutil.UnpackBuf(buf, &t); err != nil {
 		return nil, fmt.Errorf("decoding ticket: %v", err)
 	}
-	return t, nil
+	return &t, nil
 }
 
 // PolicySecret sets a secret authorization requirement on the provided entity.


### PR DESCRIPTION
unpackBuf() should be able to handle the deserialization of the Ticket, so decodeTicket() is kind of unnecessary.

Some functions returned ticket pointer, which is not necessary as ticket is not optional most of the time. 
Changed most functions to return Ticket instead of *Ticket.
*Except for PolicySecret(), because the Ticket in its return is actually optional.