### PR TITLE
Set indefinite timeout in unix.Poll call

### DIFF
--- a/tpmutil/poll_unix.go
+++ b/tpmutil/poll_unix.go
@@ -16,7 +16,7 @@ func poll(f *os.File) error {
 			Fd:     int32(f.Fd()),
 			Events: 0x1, // POLLIN
 		}}
-		timeout = 0 // No timeout
+		timeout = -1 // Indefinite timeout
 	)
 
 	if _, err := unix.Poll(fds, timeout); err != nil {


### PR DESCRIPTION
According to http://man7.org/linux/man-pages/man2/poll.2.html, zero
timeout means "return right away, even if fd isn't ready". Negative
timeout means "block until fd is ready", which is what we actually want.

Fixes #152