### PR TITLE
Adds functions tpm2_clear and tpm2_hierarchychangeauth

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -317,19 +317,21 @@ var toGoCurve = map[EllipticCurve]elliptic.Curve{
 
 // Supported TPM operations.
 const (
-	cmdEvictControl       tpmutil.Command = 0x00000120
-	cmdUndefineSpace      tpmutil.Command = 0x00000122
-	cmdDefineSpace        tpmutil.Command = 0x0000012A
-	cmdCreatePrimary      tpmutil.Command = 0x00000131
-	cmdIncrementNVCounter tpmutil.Command = 0x00000134
-	cmdWriteNV            tpmutil.Command = 0x00000137
-	cmdPCREvent           tpmutil.Command = 0x0000013C
-	cmdStartup            tpmutil.Command = 0x00000144
-	cmdShutdown           tpmutil.Command = 0x00000145
-	cmdActivateCredential tpmutil.Command = 0x00000147
-	cmdCertify            tpmutil.Command = 0x00000148
-	cmdCertifyCreation    tpmutil.Command = 0x0000014A
-	cmdReadNV             tpmutil.Command = 0x0000014E
+	cmdEvictControl        tpmutil.Command = 0x00000120
+	cmdUndefineSpace       tpmutil.Command = 0x00000122
+	cmdClear               tpmutil.Command = 0x00000126
+	cmdHierarchyChangeAuth tpmutil.Command = 0x00000129
+	cmdDefineSpace         tpmutil.Command = 0x0000012A
+	cmdCreatePrimary       tpmutil.Command = 0x00000131
+	cmdIncrementNVCounter  tpmutil.Command = 0x00000134
+	cmdWriteNV             tpmutil.Command = 0x00000137
+	cmdPCREvent            tpmutil.Command = 0x0000013C
+	cmdStartup             tpmutil.Command = 0x00000144
+	cmdShutdown            tpmutil.Command = 0x00000145
+	cmdActivateCredential  tpmutil.Command = 0x00000147
+	cmdCertify             tpmutil.Command = 0x00000148
+	cmdCertifyCreation     tpmutil.Command = 0x0000014A
+	cmdReadNV              tpmutil.Command = 0x0000014E
 	// CmdPolicySecret is a command code for TPM2_PolicySecret.
 	// It's exported for computing of default AuthPolicy value.
 	CmdPolicySecret     tpmutil.Command = 0x00000151

--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -1511,6 +1511,43 @@ func TestPlainImport(t *testing.T) {
 	}
 }
 
+func TestClear(t *testing.T) {
+	rw := openTPM(t)
+	defer rw.Close()
+
+	err := Clear(rw, HandleLockout, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession})
+	if err != nil {
+		t.Fatalf("Clear failed: %v", err)
+	}
+}
+
+func TestHierarchyChangeAuth(t *testing.T) {
+	rw := openTPM(t)
+	defer rw.Close()
+
+	err := Clear(rw, HandleLockout, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession})
+	if err != nil {
+		t.Fatalf("Clear failed: %v", err)
+	}
+
+	err = HierarchyChangeAuth(rw, HandleOwner, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession}, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte("abcd")})
+	if err != nil {
+		t.Fatalf("HierarchyChangeAuth failed: %v", err)
+	}
+
+	// try to set again password again, without valid providing valid auth
+	err = HierarchyChangeAuth(rw, HandleOwner, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession}, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte("abcd")})
+	if err == nil {
+		t.Fatal("Expected HierarchyChangeAuth to fail")
+	}
+
+	err = Clear(rw, HandleLockout, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession})
+	if err != nil {
+		t.Fatalf("Clear failed: %v", err)
+	}
+
+}
+
 func TestPolicyPCR(t *testing.T) {
 	rw := openTPM(t)
 	defer rw.Close()

--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -1535,7 +1535,7 @@ func TestHierarchyChangeAuth(t *testing.T) {
 		t.Fatalf("HierarchyChangeAuth failed: %v", err)
 	}
 
-	// try to set again password again, without valid providing valid auth
+	// try to set again password again, without providing valid auth
 	err = HierarchyChangeAuth(rw, HandleOwner, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession}, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte("abcd")})
 	if err == nil {
 		t.Fatal("Expected HierarchyChangeAuth to fail")

--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/sha256"
+	"flag"
 	"io"
 	"reflect"
 	"strings"
@@ -32,6 +33,15 @@ import (
 	. "github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 )
+
+var (
+	runClear = flag.Bool("run-clear", false, "Set to run tests which will clear hierarchy and lockout authorizations")
+)
+
+func init() {
+	testing.Init()
+	flag.Parse()
+}
 
 func openTPM(tb testing.TB) io.ReadWriteCloser {
 	tb.Helper()
@@ -1512,6 +1522,10 @@ func TestPlainImport(t *testing.T) {
 }
 
 func TestClear(t *testing.T) {
+	if !*runClear {
+		t.Skip("Missing flag: run-clear. Test skipped")
+	}
+
 	rw := openTPM(t)
 	defer rw.Close()
 
@@ -1522,6 +1536,10 @@ func TestClear(t *testing.T) {
 }
 
 func TestHierarchyChangeAuth(t *testing.T) {
+	if !*runClear {
+		t.Skip("Missing flag: run-clear. Test skipped")
+	}
+
 	rw := openTPM(t)
 	defer rw.Close()
 

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1093,6 +1093,9 @@ func encodeHierarchyChangeAuth(handle tpmutil.Handle, auth, newAuth AuthCommand)
 	}
 
 	newEncodedAuth, err := encodeAuthArea(newAuth)
+	if err != nil {
+		return nil, err
+	}
 	param, err := tpmutil.Pack(tpmutil.U16Bytes(newEncodedAuth))
 	if err != nil {
 		return nil, err

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1060,16 +1060,6 @@ func EvictControl(rw io.ReadWriter, ownerAuth string, owner, objectHandle, persi
 	return err
 }
 
-// Clears lockout, endorsement and owner hierarchy authorization values
-func Clear(rw io.ReadWriter, handle tpmutil.Handle, auth AuthCommand) error {
-	cmd, err := encodeClear(handle, auth)
-	if err != nil {
-		return err
-	}
-	_, err = runCommand(rw, TagSessions, cmdClear, tpmutil.RawBytes(cmd))
-	return err
-}
-
 func encodeClear(handle tpmutil.Handle, auth AuthCommand) ([]byte, error) {
 	ah, err := tpmutil.Pack(handle)
 	if err != nil {
@@ -1080,6 +1070,16 @@ func encodeClear(handle tpmutil.Handle, auth AuthCommand) ([]byte, error) {
 		return nil, err
 	}
 	return concat(ah, encodedAuth)
+}
+
+// Clears lockout, endorsement and owner hierarchy authorization values
+func Clear(rw io.ReadWriter, handle tpmutil.Handle, auth AuthCommand) error {
+	cmd, err := encodeClear(handle, auth)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, TagSessions, cmdClear, tpmutil.RawBytes(cmd))
+	return err
 }
 
 func encodeHierarchyChangeAuth(handle tpmutil.Handle, auth, newAuth AuthCommand) ([]byte, error) {


### PR DESCRIPTION
Adds functions to support commands tpm2_clear and tpm2_hierarchychangeauth. Together these commands can be used to take ownership of a tpm.

Using command codes found [here](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p55_Part2_Structures_pubrev.pdf#page=47)

Using parameters found [here](https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-3-Commands-01.38.pdf)

Tests in tpm2_test.go