### PR TITLE
Change newAuth parameter type in HierarchyChangeAuth

### DIFF
--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -1578,15 +1578,21 @@ func TestHierarchyChangeAuth(t *testing.T) {
 		t.Fatalf("Clear failed: %v", err)
 	}
 
-	err = HierarchyChangeAuth(rw, HandleOwner, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession}, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte("abcd")})
+	err = HierarchyChangeAuth(rw, HandleOwner, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession}, "pass1")
 	if err != nil {
 		t.Fatalf("HierarchyChangeAuth failed: %v", err)
 	}
 
-	// try to set again password again, without providing valid auth
-	err = HierarchyChangeAuth(rw, HandleOwner, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession}, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte("abcd")})
+	// try to set password again, providing invalid auth
+	err = HierarchyChangeAuth(rw, HandleOwner, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession}, "pass2")
 	if err == nil {
 		t.Fatal("Expected HierarchyChangeAuth to fail")
+	}
+
+	// set password again, providing valid auth
+	err = HierarchyChangeAuth(rw, HandleOwner, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte("pass1")}, "pass3")
+	if err != nil {
+		t.Fatalf("HierarchyChangeAuth failed: %v", err)
 	}
 
 	err = Clear(rw, HandleLockout, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession})

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1082,7 +1082,7 @@ func Clear(rw io.ReadWriter, handle tpmutil.Handle, auth AuthCommand) error {
 	return err
 }
 
-func encodeHierarchyChangeAuth(handle tpmutil.Handle, auth, newAuth AuthCommand) ([]byte, error) {
+func encodeHierarchyChangeAuth(handle tpmutil.Handle, auth AuthCommand, newAuth string) ([]byte, error) {
 	ah, err := tpmutil.Pack(handle)
 	if err != nil {
 		return nil, err
@@ -1091,21 +1091,15 @@ func encodeHierarchyChangeAuth(handle tpmutil.Handle, auth, newAuth AuthCommand)
 	if err != nil {
 		return nil, err
 	}
-
-	newEncodedAuth, err := encodeAuthArea(newAuth)
+	param, err := tpmutil.Pack(tpmutil.U16Bytes(newAuth))
 	if err != nil {
 		return nil, err
 	}
-	param, err := tpmutil.Pack(tpmutil.U16Bytes(newEncodedAuth))
-	if err != nil {
-		return nil, err
-	}
-
 	return concat(ah, encodedAuth, param)
 }
 
 // HierarchyChangeAuth changes the authorization values for a hierarchy or for the lockout authority
-func HierarchyChangeAuth(rw io.ReadWriter, handle tpmutil.Handle, auth, newAuth AuthCommand) error {
+func HierarchyChangeAuth(rw io.ReadWriter, handle tpmutil.Handle, auth AuthCommand, newAuth string) error {
 	cmd, err := encodeHierarchyChangeAuth(handle, auth, newAuth)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix bug in HierarchyChangeAuth from my PR yesterday - invalid type for newAuth

newAuth is expected to be a string, not an AuthCommand struct object

Extended TestHierarchyChangeAuth to confirm validity of change