### PR TITLE
Update Ticket.Hierarchy to be a tpmutil.Handle

### DIFF
--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -1008,7 +1008,7 @@ type TaggedProperty struct {
 // information.
 type Ticket struct {
 	Type      tpmutil.Tag
-	Hierarchy uint32
+	Hierarchy tpmutil.Handle
 	Digest    tpmutil.U16Bytes
 }
 

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1424,7 +1424,7 @@ func Shutdown(rw io.ReadWriter, typ StartupType) error {
 // is not from data that started with TPM_GENERATED_VALUE.
 var nullTicket = Ticket{
 	Type:      TagHashCheck,
-	Hierarchy: uint32(HandleNull),
+	Hierarchy: HandleNull,
 	Digest:    tpmutil.U16Bytes{},
 }
 


### PR DESCRIPTION
Fixes #177 

Per #180, it looks like it's acceptable to make some breaking changes to the API. This small change updates the type of Ticket.Hierachy to be a tpmutil.Handle.