### PR TITLE
Fix linter error in tpm2.go

### DIFF
--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1072,7 +1072,7 @@ func encodeClear(handle tpmutil.Handle, auth AuthCommand) ([]byte, error) {
 	return concat(ah, encodedAuth)
 }
 
-// Clears lockout, endorsement and owner hierarchy authorization values
+// Clear clears lockout, endorsement and owner hierarchy authorization values
 func Clear(rw io.ReadWriter, handle tpmutil.Handle, auth AuthCommand) error {
 	cmd, err := encodeClear(handle, auth)
 	if err != nil {


### PR DESCRIPTION
This change fixes the following `golint` error:

golint go-tpm/...
go-tpm/tpm2/tpm2.go:1075:1: comment on exported function Clear should be of the form "Clear ..."