### PR TITLE
TPM2: Fixed ReadPCRs() only returning the first 8 PCRs digests when more than 8 PCRs are selected.

### DIFF
--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -184,11 +184,11 @@ func ReadPCRs(rw io.ReadWriter, sel PCRSelection) (map[int][]byte, error) {
 		if len(selPCRs) == 0 {
 			break
 		}
-		Cmd, err := encodeTPMLPCRSelection(tpm2.PCRSelection{Hash: sel.Hash, PCRs: selPCRs})
+		Cmd, err := encodeTPMLPCRSelection(PCRSelection{Hash: sel.Hash, PCRs: selPCRs})
 		if err != nil {
 			return nil, err
 		}
-		resp, err := runCommand(rw, tpm2.TagNoSessions, tpm2.CmdPCRRead, tpmutil.RawBytes(Cmd))
+		resp, err := runCommand(rw, TagNoSessions, CmdPCRRead, tpmutil.RawBytes(Cmd))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This is a follow up to issue #202.

The bug was due to the fact that the old code called the `TPM2_PCR_Read` command only once. This worked fine when 8 PCRs at most were selected, but returned only the first 8 PCRs digests if more. This can be explained by the fact that one single `TPM2_PCR_Read` command can only return 1 single `TPML_DIGEST`, which consists of, at most, 8 digests. Therefore, if we select PCRs `{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20}`, one call to `TPM2_PCR_Read` would only return the digests of PCRs `{0,1,2,3,4,5,6,7}`.

The bug is fixed by calling the `TPM2_PCR_Read` command as many times as needed, and skipping, at each call, the 8 PCRs that were selected by the previous call.

Signed-off-by: El Mostafa IDRASSI <mostafa.idrassi@tutanota.com>