### PR TITLE
TPM2: Added check when parsing TPMLPCRSelection in case of selection of a PCR's index which exceeds max value permitted

### DIFF
--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -73,6 +73,9 @@ func encodeTPMLPCRSelection(sel ...PCRSelection) ([]byte, error) {
 
 		// s[i].PCRs parameter is indexes of PCRs, convert that to set bits.
 		for _, n := range s.PCRs {
+			if n >= 8*sizeOfPCRSelect {
+				continue 
+			}
 			byteNum := n / 8
 			bytePos := byte(1 << byte(n%8))
 			ts.PCRs[byteNum] |= bytePos

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -74,7 +74,7 @@ func encodeTPMLPCRSelection(sel ...PCRSelection) ([]byte, error) {
 		// s[i].PCRs parameter is indexes of PCRs, convert that to set bits.
 		for _, n := range s.PCRs {
 			if n >= 8*sizeOfPCRSelect {
-				continue 
+				return nil,  fmt.Errorf("PCR index %d is out of range (exceeds maximum value %d)", n, 8*sizeOfPCRSelect-1)
 			}
 			byteNum := n / 8
 			bytePos := byte(1 << byte(n%8))


### PR DESCRIPTION
The current implementation makes use of `sizeOfPCRSelect` set to `3`. This means that the maximum size of the `pcrSelect` byte array in `tpmsPCRSelection` is `3`, which means it can only deal with the selection of PCRs from 0 to 23. Attempting to select PCR 24 for example (which might exist on some TPMs) leads to a `panic: runtime error: index out of range [3] with length 3` since `ts.PCRs[byteNum] |= bytePos` tries to access index 3 of the byte array, which is out of range.

This can be fixed by adding a check beforehand, and skipping the PCR if it's index exceeds the maximum value permitted, independently of the value of `sizeOfPCRSelect`.

Signed-off-by: El Mostafa IDRASSI <mostafa.idrassi@tutanota.com>