### PR TITLE
TPM2: Updated ReadPCRs doc and added TestReadAllPCRs

### DIFF
--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -178,7 +178,7 @@ func decodeReadPCRs(in []byte) (map[int][]byte, error) {
 
 // ReadPCRs reads PCR values from the TPM.
 // This is only a wrapper over TPM2_PCR_Read() call, thus can only return
-// at most 8 PCRs digests
+// at most 8 PCRs digests.
 func ReadPCRs(rw io.ReadWriter, sel PCRSelection) (map[int][]byte, error) {
 	Cmd, err := encodeTPMLPCRSelection(sel)
 	if err != nil {

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -177,6 +177,8 @@ func decodeReadPCRs(in []byte) (map[int][]byte, error) {
 }
 
 // ReadPCRs reads PCR values from the TPM.
+// This is only a wrapper over TPM2_PCR_Read() call, thus can only return
+// at most 8 PCRs digests
 func ReadPCRs(rw io.ReadWriter, sel PCRSelection) (map[int][]byte, error) {
 	Cmd, err := encodeTPMLPCRSelection(sel)
 	if err != nil {


### PR DESCRIPTION
Updated `ReadPCRs` doc to make it clear the command is only a wrapper over `TPM2_PCR_Read` and can return **at most** 8 `PCRs` digests.

Added `TestReadAllPCRs` which showcases how to use `ReadPCRs` in a loop to gather all the PCRs digests (i.e. more than 8 `PCRs`).

Should close #202.