### PR TITLE
TPM2: Added CertifyEx and encodeCertifyEx

### DIFF
--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -618,11 +618,6 @@ func (p Private) Encode() ([]byte, error) {
 	return tpmutil.Pack(p)
 }
 
-type tpmtSigScheme struct {
-	Scheme Algorithm
-	Hash   Algorithm
-}
-
 // AttestationData contains data attested by TPM commands (like Certify).
 type AttestationData struct {
 	Magic                uint32

--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -575,6 +575,144 @@ func TestCertify(t *testing.T) {
 	})
 }
 
+func TestCertifyEx(t *testing.T) {
+	rw := openTPM(t)
+	defer rw.Close()
+
+	params := Public{
+		Type:       AlgRSA,
+		NameAlg:    AlgSHA256,
+		Attributes: FlagSignerDefault,
+		RSAParameters: &RSAParams{
+			Sign: &SigScheme{
+				Alg:  AlgRSASSA,
+				Hash: AlgSHA256,
+			},
+			KeyBits: 2048,
+		},
+	}
+	signerHandle, signerPub, err := CreatePrimary(rw, HandleOwner, pcrSelection7, emptyPassword, defaultPassword, params)
+	if err != nil {
+		t.Fatalf("CreatePrimary(signer) failed: %s", err)
+	}
+	defer FlushContext(rw, signerHandle)
+
+	subjectHandle, subjectPub, err := CreatePrimary(rw, HandlePlatform, pcrSelection7, emptyPassword, defaultPassword, params)
+	if err != nil {
+		t.Fatalf("CreatePrimary(subject) failed: %s", err)
+	}
+	defer FlushContext(rw, subjectHandle)
+
+	attest, sig, err := CertifyEx(rw, defaultPassword, defaultPassword, subjectHandle, signerHandle, nil, SigScheme{Alg: AlgRSASSA, Hash: AlgSHA256, Count: 0})
+	if err != nil {
+		t.Errorf("Certify failed: %s", err)
+		return
+	}
+
+	attestHash := sha256.Sum256(attest)
+	if err := rsa.VerifyPKCS1v15(signerPub.(*rsa.PublicKey), crypto.SHA256, attestHash[:], sig); err != nil {
+		t.Errorf("Signature verification failed: %v", err)
+	}
+
+	t.Run("DecodeAttestationData", func(t *testing.T) {
+		ad, err := DecodeAttestationData(attest)
+		if err != nil {
+			t.Fatal("DecodeAttestationData:", err)
+		}
+		params := Public{
+			Type:       AlgRSA,
+			NameAlg:    AlgSHA256,
+			Attributes: FlagSignerDefault,
+			RSAParameters: &RSAParams{
+				Sign: &SigScheme{
+					Alg:  AlgRSASSA,
+					Hash: AlgSHA256,
+				},
+				KeyBits: 2048,
+				// Note: we don't include Exponent because CreatePrimary also
+				// returns Public without it.
+				ModulusRaw: subjectPub.(*rsa.PublicKey).N.Bytes(),
+			},
+		}
+		matches, err := ad.AttestedCertifyInfo.Name.MatchesPublic(params)
+		if err != nil {
+			t.Fatalf("AttestedCertifyInfo.Name.MatchesPublic error: %v", err)
+		}
+		if !matches {
+			t.Error("Name in AttestationData doesn't match Public structure of subject")
+		}
+	})
+}
+
+func TestCertifyExAlgNull(t *testing.T) {
+	rw := openTPM(t)
+	defer rw.Close()
+
+	params := Public{
+		Type:       AlgRSA,
+		NameAlg:    AlgSHA256,
+		Attributes: FlagSignerDefault,
+		RSAParameters: &RSAParams{
+			Sign: &SigScheme{
+				Alg:  AlgRSASSA,
+				Hash: AlgSHA256,
+			},
+			KeyBits: 2048,
+		},
+	}
+	signerHandle, signerPub, err := CreatePrimary(rw, HandleOwner, pcrSelection7, emptyPassword, defaultPassword, params)
+	if err != nil {
+		t.Fatalf("CreatePrimary(signer) failed: %s", err)
+	}
+	defer FlushContext(rw, signerHandle)
+
+	subjectHandle, subjectPub, err := CreatePrimary(rw, HandlePlatform, pcrSelection7, emptyPassword, defaultPassword, params)
+	if err != nil {
+		t.Fatalf("CreatePrimary(subject) failed: %s", err)
+	}
+	defer FlushContext(rw, subjectHandle)
+
+	attest, sig, err := CertifyEx(rw, defaultPassword, defaultPassword, subjectHandle, signerHandle, nil, SigScheme{Alg: AlgNull, Hash: AlgSHA256, Count: 0})
+	if err != nil {
+		t.Errorf("Certify failed: %s", err)
+		return
+	}
+
+	attestHash := sha256.Sum256(attest)
+	if err := rsa.VerifyPKCS1v15(signerPub.(*rsa.PublicKey), crypto.SHA256, attestHash[:], sig); err != nil {
+		t.Errorf("Signature verification failed: %v", err)
+	}
+
+	t.Run("DecodeAttestationData", func(t *testing.T) {
+		ad, err := DecodeAttestationData(attest)
+		if err != nil {
+			t.Fatal("DecodeAttestationData:", err)
+		}
+		params := Public{
+			Type:       AlgRSA,
+			NameAlg:    AlgSHA256,
+			Attributes: FlagSignerDefault,
+			RSAParameters: &RSAParams{
+				Sign: &SigScheme{
+					Alg:  AlgRSASSA,
+					Hash: AlgSHA256,
+				},
+				KeyBits: 2048,
+				// Note: we don't include Exponent because CreatePrimary also
+				// returns Public without it.
+				ModulusRaw: subjectPub.(*rsa.PublicKey).N.Bytes(),
+			},
+		}
+		matches, err := ad.AttestedCertifyInfo.Name.MatchesPublic(params)
+		if err != nil {
+			t.Fatalf("AttestedCertifyInfo.Name.MatchesPublic error: %v", err)
+		}
+		if !matches {
+			t.Error("Name in AttestationData doesn't match Public structure of subject")
+		}
+	})
+}
+
 func TestCertifyExternalKey(t *testing.T) {
 	rw := openTPM(t)
 	defer rw.Close()

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1559,7 +1559,16 @@ func encodeCertifyEx(objectAuth, signerAuth string, object, signer tpmutil.Handl
 		return nil, err
 	}
 
-	params, err := tpmutil.Pack(qualifyingData, scheme)
+	// TODO: This is just a temporary workaround for the special case where the scheme is AlgNull, 
+	//		 where we should only pack AlgNull with no additional following hash alg, since
+	//		 tpmtSigScheme is not a perfect representation of TPMT_SIG_SCHEME.
+	//		 See issue https://github.com/google/go-tpm/issues/215
+	var params []byte
+	if scheme.Scheme == AlgNull {
+		params, err = tpmutil.Pack(qualifyingData, AlgNull)
+	} else {
+		params, err = tpmutil.Pack(qualifyingData, scheme)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1600,8 +1600,9 @@ func decodeCertify(resp []byte) ([]byte, []byte, error) {
 }
 
 // Certify generates a signature of a loaded TPM object with a signing key
-// signer. Returned values are: attestation data (TPMS_ATTEST), signature and
-// error, if any.
+// signer. This function calls encodeCertify which makes use of the hardcoded 
+// signing scheme {AlgRSASSA, AlgSHA256}. Returned values are: attestation data (TPMS_ATTEST), 
+// signature and error, if any.
 func Certify(rw io.ReadWriter, objectAuth, signerAuth string, object, signer tpmutil.Handle, qualifyingData []byte) ([]byte, []byte, error) {
 	Cmd, err := encodeCertify(objectAuth, signerAuth, object, signer, qualifyingData)
 	if err != nil {

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1526,13 +1526,13 @@ func Sign(rw io.ReadWriter, key tpmutil.Handle, password string, digest []byte, 
 	return SignWithSession(rw, HandlePasswordSession, key, password, digest, validation, sigScheme)
 }
 
-func encodeCertify(parentAuth, ownerAuth string, object, signer tpmutil.Handle, qualifyingData tpmutil.U16Bytes) ([]byte, error) {
+func encodeCertify(objectAuth, signerAuth string, object, signer tpmutil.Handle, qualifyingData tpmutil.U16Bytes) ([]byte, error) {
 	ha, err := tpmutil.Pack(object, signer)
 	if err != nil {
 		return nil, err
 	}
 
-	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(parentAuth)}, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(ownerAuth)})
+	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(objectAuth)}, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(signerAuth)})
 	if err != nil {
 		return nil, err
 	}
@@ -1548,13 +1548,13 @@ func encodeCertify(parentAuth, ownerAuth string, object, signer tpmutil.Handle, 
 
 // This function differs from encodeCertify in that it takes the scheme
 // to be used as an additional argument.
-func encodeCertifyEx(parentAuth, ownerAuth string, object, signer tpmutil.Handle, qualifyingData tpmutil.U16Bytes, scheme tpmtSigScheme) ([]byte, error) {
+func encodeCertifyEx(objectAuth, signerAuth string, object, signer tpmutil.Handle, qualifyingData tpmutil.U16Bytes, scheme tpmtSigScheme) ([]byte, error) {
 	ha, err := tpmutil.Pack(object, signer)
 	if err != nil {
 		return nil, err
 	}
 
-	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(parentAuth)}, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(ownerAuth)})
+	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(objectAuth)}, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(signerAuth)})
 	if err != nil {
 		return nil, err
 	}
@@ -1602,8 +1602,8 @@ func decodeCertify(resp []byte) ([]byte, []byte, error) {
 // Certify generates a signature of a loaded TPM object with a signing key
 // signer. Returned values are: attestation data (TPMS_ATTEST), signature and
 // error, if any.
-func Certify(rw io.ReadWriter, parentAuth, ownerAuth string, object, signer tpmutil.Handle, qualifyingData []byte) ([]byte, []byte, error) {
-	Cmd, err := encodeCertify(parentAuth, ownerAuth, object, signer, qualifyingData)
+func Certify(rw io.ReadWriter, objectAuth, signerAuth string, object, signer tpmutil.Handle, qualifyingData []byte) ([]byte, []byte, error) {
+	Cmd, err := encodeCertify(objectAuth, signerAuth, object, signer, qualifyingData)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1620,8 +1620,8 @@ func Certify(rw io.ReadWriter, parentAuth, ownerAuth string, object, signer tpmu
 // of encodeCertify.
 // Returned values are: attestation data (TPMS_ATTEST), signature and
 // error, if any.
-func CertifyEx(rw io.ReadWriter, parentAuth, ownerAuth string, object, signer tpmutil.Handle, qualifyingData []byte, scheme tpmtSigScheme) ([]byte, []byte, error) {
-	Cmd, err := encodeCertifyEx(parentAuth, ownerAuth, object, signer, qualifyingData, scheme)
+func CertifyEx(rw io.ReadWriter, objectAuth, signerAuth string, object, signer tpmutil.Handle, qualifyingData []byte, scheme tpmtSigScheme) ([]byte, []byte, error) {
+	Cmd, err := encodeCertifyEx(objectAuth, signerAuth, object, signer, qualifyingData, scheme)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1548,7 +1548,7 @@ func encodeCertify(parentAuth, ownerAuth string, object, signer tpmutil.Handle, 
 
 // This function differs from encodeCertify in that it takes the scheme
 // to be used as an additional argument.
-func encodeCertifyEx(parentAuth, ownerAuth string, object, signer tpmutil.Handle, qualifyingData tpmutil.U16Bytes, scheme tpmtSigSchemegScheme) ([]byte, error) {
+func encodeCertifyEx(parentAuth, ownerAuth string, object, signer tpmutil.Handle, qualifyingData tpmutil.U16Bytes, scheme tpmtSigScheme) ([]byte, error) {
 	ha, err := tpmutil.Pack(object, signer)
 	if err != nil {
 		return nil, err

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1546,8 +1546,7 @@ func encodeCertify(objectAuth, signerAuth string, object, signer tpmutil.Handle,
 	return concat(ha, auth, params)
 }
 
-// This function differs from encodeCertify in that it takes the scheme
-// to be used as an additional argument.
+// This function differs from encodeCertify in that it takes the scheme to be used as an additional argument.
 func encodeCertifyEx(objectAuth, signerAuth string, object, signer tpmutil.Handle, qualifyingData tpmutil.U16Bytes, scheme tpmtSigScheme) ([]byte, error) {
 	ha, err := tpmutil.Pack(object, signer)
 	if err != nil {
@@ -1560,9 +1559,9 @@ func encodeCertifyEx(objectAuth, signerAuth string, object, signer tpmutil.Handl
 	}
 
 	// TODO: This is just a temporary workaround for the special case where the scheme is AlgNull, 
-	//		 where we should only pack AlgNull with no additional following hash alg, since
-	//		 tpmtSigScheme is not a perfect representation of TPMT_SIG_SCHEME.
-	//		 See issue https://github.com/google/go-tpm/issues/215
+	// where we should only pack AlgNull with no additional following hash alg, since
+	// tpmtSigScheme is not a perfect representation of TPMT_SIG_SCHEME.
+	// See issue https://github.com/google/go-tpm/issues/215
 	var params []byte
 	if scheme.Scheme == AlgNull {
 		params, err = tpmutil.Pack(qualifyingData, AlgNull)
@@ -1613,11 +1612,11 @@ func decodeCertify(resp []byte) ([]byte, []byte, error) {
 // signing scheme {AlgRSASSA, AlgSHA256}. Returned values are: attestation data (TPMS_ATTEST), 
 // signature and error, if any.
 func Certify(rw io.ReadWriter, objectAuth, signerAuth string, object, signer tpmutil.Handle, qualifyingData []byte) ([]byte, []byte, error) {
-	Cmd, err := encodeCertify(objectAuth, signerAuth, object, signer, qualifyingData)
+	cmd, err := encodeCertify(objectAuth, signerAuth, object, signer, qualifyingData)
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, CmdCertify, tpmutil.RawBytes(Cmd))
+	resp, err := runCommand(rw, TagSessions, CmdCertify, tpmutil.RawBytes(cmd))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1627,15 +1626,14 @@ func Certify(rw io.ReadWriter, objectAuth, signerAuth string, object, signer tpm
 // CertifyEx generates a signature of a loaded TPM object with a signing key
 // signer. This function differs from Certify in that it takes the scheme
 // to be used as an additional argument and calls encodeCertifyEx instead
-// of encodeCertify.
-// Returned values are: attestation data (TPMS_ATTEST), signature and
-// error, if any.
+// of encodeCertify. Returned values are: attestation data (TPMS_ATTEST), 
+// signature and error, if any.
 func CertifyEx(rw io.ReadWriter, objectAuth, signerAuth string, object, signer tpmutil.Handle, qualifyingData []byte, scheme tpmtSigScheme) ([]byte, []byte, error) {
-	Cmd, err := encodeCertifyEx(objectAuth, signerAuth, object, signer, qualifyingData, scheme)
+	cmd, err := encodeCertifyEx(objectAuth, signerAuth, object, signer, qualifyingData, scheme)
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, CmdCertify, tpmutil.RawBytes(Cmd))
+	resp, err := runCommand(rw, TagSessions, CmdCertify, tpmutil.RawBytes(cmd))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
These functions differ from `Certify` and `encodeCertify` in that they take the `scheme` to be used as an additional argument.
Should close #210.

Signed-off-by: El Mostafa IDRASSI <mostafa.idrassi@tutanota.com>