### PR TITLE
TPM2: Rework NVDefineSpaceEx 

### DIFF
--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1205,17 +1205,22 @@ func NVDefineSpace(rw io.ReadWriter, owner, handle tpmutil.Handle, ownerAuth, au
 		AuthPolicy: policy,
 		DataSize:   dataSize,
 	}
-	return NVDefineSpaceEx(rw, owner, ownerAuth, authString, nvPub)
+	authArea := AuthCommand{
+		Session:    HandlePasswordSession,
+		Attributes: AttrContinueSession,
+		Auth:       []byte(ownerAuth),
+	}
+	return NVDefineSpaceEx(rw, owner, authString, nvPub, authArea)
 
 }
 
-// NVDefineSpaceEx accepts NVPublic structure and is more flexible.
-func NVDefineSpaceEx(rw io.ReadWriter, owner tpmutil.Handle, ownerAuth, authVal string, pubInfo NVPublic) error {
+// NVDefineSpaceEx accepts NVPublic structure and AuthCommand, allowing more flexibility.
+func NVDefineSpaceEx(rw io.ReadWriter, owner tpmutil.Handle, authVal string, pubInfo NVPublic, authArea AuthCommand) error {
 	ha, err := tpmutil.Pack(owner)
 	if err != nil {
 		return err
 	}
-	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(ownerAuth)})
+	auth, err := encodeAuthArea(authArea)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
removed auth arguments and replaced it with AuthCommand struct. 
Allows use of digest auth and not just PasswortAuth
More flexible

Signed-off-by: Christopher Meis <christopher.meis@9elements.com>