### PR TITLE
TPM12: Implement GetCapVersionVal function

### DIFF
--- a/tpm/constants.go
+++ b/tpm/constants.go
@@ -79,6 +79,7 @@ const (
 	CapNVList   uint32 = 0x0000000D
 	CapNVIndex  uint32 = 0x00000011
 	CapHandle   uint32 = 0x00000014
+	CapVersion  uint32 = 0x0000001A
 )
 
 // SubCapabilities

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -165,7 +165,7 @@ func Quote2(rw io.ReadWriter, handle tpmutil.Handle, data []byte, pcrVals []int,
 		return nil, err
 	}
 
-	// TODO(tmroeder): use the returned capVersionInfo.
+	// TODO(tmroeder): use the returned CapVersion.
 	pcrShort, _, capBytes, sig, ra, ret, err := quote2(rw, handle, hash, pcrSel, addVersion, ca)
 	if err != nil {
 		return nil, err
@@ -1161,6 +1161,16 @@ func GetAlgs(rw io.ReadWriter) ([]Algorithm, error) {
 
 	}
 	return algs, nil
+}
+
+func GetCapVersionVal(rw io.ReadWriter) (*CapVersionInfo, error) {
+	var capVer CapVersionInfo
+	buf, err := getCapability(rw, CapVersion, 0)
+	err = capVer.Decode(buf)
+	if err != nil {
+		return nil, err
+	}
+	return &capVer, nil
 }
 
 // GetNVList returns a list of TPM_NV_INDEX values that


### PR DESCRIPTION
Modify CapVersionInfo structure
Implement Decode function for modified structure
Implement GetCapVersionVal function to retrieve Version, Spec, Errata information from the TPM12

Signed-off-by: Christopher Meis <christopher.meis@9elements.com>