### PR TITLE
Add support for hash sequence

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -361,6 +361,7 @@ const (
 	CmdDictionaryAttackLockReset  tpmutil.Command = 0x00000139
 	CmdDictionaryAttackParameters tpmutil.Command = 0x0000013A
 	CmdPCREvent                   tpmutil.Command = 0x0000013C
+	CmdSequenceComplete           tpmutil.Command = 0x0000013E
 	CmdStartup                    tpmutil.Command = 0x00000144
 	CmdShutdown                   tpmutil.Command = 0x00000145
 	CmdActivateCredential         tpmutil.Command = 0x00000147
@@ -375,6 +376,7 @@ const (
 	CmdLoad                       tpmutil.Command = 0x00000157
 	CmdQuote                      tpmutil.Command = 0x00000158
 	CmdRSADecrypt                 tpmutil.Command = 0x00000159
+	CmdSequenceUpdate             tpmutil.Command = 0x0000015C
 	CmdSign                       tpmutil.Command = 0x0000015D
 	CmdUnseal                     tpmutil.Command = 0x0000015E
 	CmdContextLoad                tpmutil.Command = 0x00000161
@@ -393,14 +395,12 @@ const (
 	CmdGetCapability              tpmutil.Command = 0x0000017A
 	CmdGetRandom                  tpmutil.Command = 0x0000017B
 	CmdHash                       tpmutil.Command = 0x0000017D
-	CmdHashSequenceStart          tpmutil.Command = 0x00000186
-	CmdSequenceUpdate             tpmutil.Command = 0x0000015C
-	CmdSequenceComplete           tpmutil.Command = 0x0000013E
-	CmdEventSequenceComplete      tpmutil.Command = 0x00000185
 	CmdPCRRead                    tpmutil.Command = 0x0000017E
 	CmdPolicyPCR                  tpmutil.Command = 0x0000017F
 	CmdReadClock                  tpmutil.Command = 0x00000181
 	CmdPCRExtend                  tpmutil.Command = 0x00000182
+	CmdEventSequenceComplete      tpmutil.Command = 0x00000185
+	CmdHashSequenceStart          tpmutil.Command = 0x00000186
 	CmdPolicyGetDigest            tpmutil.Command = 0x00000189
 	CmdPolicyPassword             tpmutil.Command = 0x0000018C
 	CmdEncryptDecrypt2            tpmutil.Command = 0x00000193

--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -393,6 +393,9 @@ const (
 	CmdGetCapability              tpmutil.Command = 0x0000017A
 	CmdGetRandom                  tpmutil.Command = 0x0000017B
 	CmdHash                       tpmutil.Command = 0x0000017D
+	CmdHashSequenceStart          tpmutil.Command = 0x00000186
+	CmdSequenceUpdate             tpmutil.Command = 0x0000015C
+	CmdSequenceComplete           tpmutil.Command = 0x0000013E
 	CmdPCRRead                    tpmutil.Command = 0x0000017E
 	CmdPolicyPCR                  tpmutil.Command = 0x0000017F
 	CmdReadClock                  tpmutil.Command = 0x00000181

--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -396,6 +396,7 @@ const (
 	CmdHashSequenceStart          tpmutil.Command = 0x00000186
 	CmdSequenceUpdate             tpmutil.Command = 0x0000015C
 	CmdSequenceComplete           tpmutil.Command = 0x0000013E
+	CmdEventSequenceComplete      tpmutil.Command = 0x00000185
 	CmdPCRRead                    tpmutil.Command = 0x0000017E
 	CmdPolicyPCR                  tpmutil.Command = 0x0000017F
 	CmdReadClock                  tpmutil.Command = 0x00000181

--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -430,15 +430,12 @@ func testHashSequence(t *testing.T, rw io.ReadWriter, hierarchy tpmutil.Handle, 
 	if err != nil {
 		t.Fatalf("HashSequenceStart failed: %v", err)
 	}
-
 	defer FlushContext(rw, seq)
 
 	for len(data) > maxDigestBuffer {
-		err = SequenceUpdate(rw, seqAuth, seq, data[:maxDigestBuffer])
-		if err != nil {
+		if err = SequenceUpdate(rw, seqAuth, seq, data[:maxDigestBuffer]); err != nil {
 			t.Fatalf("SequenceUpdate failed: %v", err)
 		}
-
 		data = data[maxDigestBuffer:]
 	}
 
@@ -446,7 +443,6 @@ func testHashSequence(t *testing.T, rw io.ReadWriter, hierarchy tpmutil.Handle, 
 	if err != nil {
 		t.Fatalf("SequenceComplete failed: %v", err)
 	}
-
 	return digest, ticket
 }
 
@@ -472,8 +468,8 @@ func TestHashSequence(t *testing.T) {
 	bufferSizes := []int{512, 1024, 2048, 4096}
 	for _, bufferSize := range bufferSizes {
 		buffer := make([]byte, bufferSize)
-		_, err := rand.Read(buffer)
-		if err != nil {
+
+		if _, err := rand.Read(buffer); err != nil {
 			t.Fatalf("rand.Read failed: %v", err)
 		}
 

--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -33,7 +33,6 @@ import (
 	"testing"
 
 	"github.com/google/go-tpm-tools/simulator"
-	"github.com/google/go-tpm/tpm2"
 	. "github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 )
@@ -432,7 +431,7 @@ func testHashSequence(t *testing.T, rw io.ReadWriter, hierarchy tpmutil.Handle, 
 		t.Fatalf("HashSequenceStart failed: %v", err)
 	}
 
-	defer tpm2.FlushContext(rw, seq)
+	defer FlushContext(rw, seq)
 
 	for len(data) > maxDigestBuffer {
 		err = SequenceUpdate(rw, seqAuth, seq, data[:maxDigestBuffer])

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1565,20 +1565,17 @@ func encodeEventSequenceComplete(auths []AuthCommand, pcrHandle, seqHandle tpmut
 
 func decodeEventSequenceComplete(resp []byte) ([]*HashValue, error) {
 	var paramSize uint32
-	var hashCount int32
+	var hashCount uint32
 
 	buf := bytes.NewBuffer(resp)
 	err := tpmutil.UnpackBuf(buf, &paramSize, &hashCount)
 	if err != nil {
 		return nil, err
 	}
-	if hashCount < 0 {
-		return nil, bytes.ErrTooLarge
-	}
 
 	buf.Truncate(int(paramSize))
 	digests := make([]*HashValue, hashCount)
-	for i := int32(0); i < hashCount; i++ {
+	for i := uint32(0); i < hashCount; i++ {
 		digests[i], err = decodeHashValue(buf)
 		if err != nil {
 			return nil, err

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1459,6 +1459,71 @@ func Hash(rw io.ReadWriter, alg Algorithm, buf tpmutil.U16Bytes, hierarchy tpmut
 	return decodeHash(resp)
 }
 
+// HashSequenceStart starts a hash or an event sequence. If hashAlg is an
+// implemented hash, then a hash sequence is started. If hashAlg is
+// TPM_ALG_NULL, then an event sequence is started.
+func HashSequenceStart(rw io.ReadWriter, sequenceAuth string, hashAlg Algorithm) (seqHandle tpmutil.Handle, err error) {
+	resp, err := runCommand(rw, TagNoSessions, CmdHashSequenceStart, tpmutil.U16Bytes(sequenceAuth), hashAlg)
+	if err != nil {
+		return 0, err
+	}
+	var handle tpmutil.Handle
+	_, err = tpmutil.Unpack(resp, &handle)
+	return handle, err
+}
+
+func encodeSequenceUpdateOrComplete(sequenceAuth string, seqHandle tpmutil.Handle, buf tpmutil.U16Bytes) ([]byte, error) {
+	ha, err := tpmutil.Pack(seqHandle)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(sequenceAuth)})
+	if err != nil {
+		return nil, err
+	}
+	params, err := tpmutil.Pack(buf)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, params)
+}
+
+// SequenceUpdate is used to add data to a hash or HMAC sequence.
+func SequenceUpdate(rw io.ReadWriter, sequenceAuth string, seqHandle tpmutil.Handle, buffer []byte) error {
+	cmd, err := encodeSequenceUpdateOrComplete(sequenceAuth, seqHandle, buffer)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, TagSessions, CmdSequenceUpdate, tpmutil.RawBytes(cmd))
+	return err
+}
+
+func decodeSequenceComplete(resp []byte) ([]byte, *Ticket, error) {
+	var digest tpmutil.U16Bytes
+	var validation Ticket
+	var paramSize uint32
+
+	_, err := tpmutil.Unpack(resp, &paramSize, &digest, &validation)
+	if err != nil {
+		return nil, nil, err
+	}
+	return digest, &validation, nil
+}
+
+// SequenceComplete adds the last part of data, if any, to a hash/HMAC sequence
+// and returns the result.
+func SequenceComplete(rw io.ReadWriter, sequenceAuth string, seqHandle tpmutil.Handle, hierarchy tpmutil.Handle, buffer []byte) (digest []byte, validation *Ticket, err error) {
+	cmd, err := encodeSequenceUpdateOrComplete(sequenceAuth, seqHandle, buffer)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := runCommand(rw, TagSessions, CmdSequenceComplete, tpmutil.RawBytes(cmd), hierarchy)
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeSequenceComplete(resp)
+}
+
 // Startup initializes a TPM (usually done by the OS).
 func Startup(rw io.ReadWriter, typ StartupType) error {
 	_, err := runCommand(rw, TagNoSessions, CmdStartup, typ)

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1472,7 +1472,7 @@ func HashSequenceStart(rw io.ReadWriter, sequenceAuth string, hashAlg Algorithm)
 	return handle, err
 }
 
-func encodeSequenceUpdateOrComplete(sequenceAuth string, seqHandle tpmutil.Handle, buf tpmutil.U16Bytes) ([]byte, error) {
+func encodeSequenceUpdate(sequenceAuth string, seqHandle tpmutil.Handle, buf tpmutil.U16Bytes) ([]byte, error) {
 	ha, err := tpmutil.Pack(seqHandle)
 	if err != nil {
 		return nil, err
@@ -1490,7 +1490,7 @@ func encodeSequenceUpdateOrComplete(sequenceAuth string, seqHandle tpmutil.Handl
 
 // SequenceUpdate is used to add data to a hash or HMAC sequence.
 func SequenceUpdate(rw io.ReadWriter, sequenceAuth string, seqHandle tpmutil.Handle, buffer []byte) error {
-	cmd, err := encodeSequenceUpdateOrComplete(sequenceAuth, seqHandle, buffer)
+	cmd, err := encodeSequenceUpdate(sequenceAuth, seqHandle, buffer)
 	if err != nil {
 		return err
 	}
@@ -1510,14 +1510,30 @@ func decodeSequenceComplete(resp []byte) ([]byte, *Ticket, error) {
 	return digest, &validation, nil
 }
 
+func encodeSequenceComplete(sequenceAuth string, seqHandle, hierarchy tpmutil.Handle, buf tpmutil.U16Bytes) ([]byte, error) {
+	ha, err := tpmutil.Pack(seqHandle)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(sequenceAuth)})
+	if err != nil {
+		return nil, err
+	}
+	params, err := tpmutil.Pack(buf, hierarchy)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, params)
+}
+
 // SequenceComplete adds the last part of data, if any, to a hash/HMAC sequence
 // and returns the result.
-func SequenceComplete(rw io.ReadWriter, sequenceAuth string, seqHandle tpmutil.Handle, hierarchy tpmutil.Handle, buffer []byte) (digest []byte, validation *Ticket, err error) {
-	cmd, err := encodeSequenceUpdateOrComplete(sequenceAuth, seqHandle, buffer)
+func SequenceComplete(rw io.ReadWriter, sequenceAuth string, seqHandle, hierarchy tpmutil.Handle, buffer []byte) (digest []byte, validation *Ticket, err error) {
+	cmd, err := encodeSequenceComplete(sequenceAuth, seqHandle, hierarchy, buffer)
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, CmdSequenceComplete, tpmutil.RawBytes(cmd), hierarchy)
+	resp, err := runCommand(rw, TagSessions, CmdSequenceComplete, tpmutil.RawBytes(cmd))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1510,8 +1510,7 @@ func decodeSequenceComplete(resp []byte) ([]byte, *Ticket, error) {
 	var validation Ticket
 	var paramSize uint32
 
-	_, err := tpmutil.Unpack(resp, &paramSize, &digest, &validation)
-	if err != nil {
+	if _, err := tpmutil.Unpack(resp, &paramSize, &digest, &validation); err != nil {
 		return nil, nil, err
 	}
 	return digest, &validation, nil
@@ -1566,18 +1565,17 @@ func encodeEventSequenceComplete(auths []AuthCommand, pcrHandle, seqHandle tpmut
 func decodeEventSequenceComplete(resp []byte) ([]*HashValue, error) {
 	var paramSize uint32
 	var hashCount uint32
+	var err error
 
 	buf := bytes.NewBuffer(resp)
-	err := tpmutil.UnpackBuf(buf, &paramSize, &hashCount)
-	if err != nil {
+	if err := tpmutil.UnpackBuf(buf, &paramSize, &hashCount); err != nil {
 		return nil, err
 	}
 
 	buf.Truncate(int(paramSize))
 	digests := make([]*HashValue, hashCount)
 	for i := uint32(0); i < hashCount; i++ {
-		digests[i], err = decodeHashValue(buf)
-		if err != nil {
+		if digests[i], err = decodeHashValue(buf); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Adding support for `HashSequenceStart`, `SequenceUpdate` and `SequenceComplete`.
Closes issue #179 