### PR TITLE
Add support for StartAuthSessionEx accepting full SymScheme definition

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -84,6 +84,7 @@ const (
 	AlgSHA384    Algorithm = 0x000C
 	AlgSHA512    Algorithm = 0x000D
 	AlgNull      Algorithm = 0x0010
+	AlgSM4       Algorithm = 0x0013
 	AlgRSASSA    Algorithm = 0x0014
 	AlgRSAES     Algorithm = 0x0015
 	AlgRSAPSS    Algorithm = 0x0016
@@ -94,6 +95,7 @@ const (
 	AlgKDF2      Algorithm = 0x0021
 	AlgECC       Algorithm = 0x0023
 	AlgSymCipher Algorithm = 0x0025
+	AlgCamellia  Algorithm = 0x0026
 	AlgCTR       Algorithm = 0x0040
 	AlgOFB       Algorithm = 0x0041
 	AlgCBC       Algorithm = 0x0042

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -826,7 +826,7 @@ func PolicyGetDigest(rw io.ReadWriter, handle tpmutil.Handle) ([]byte, error) {
 	return digest, err
 }
 
-func encodeStartAuthSession(tpmKey, bindKey tpmutil.Handle, nonceCaller, secret tpmutil.U16Bytes, se SessionType, sym, hashAlg Algorithm) ([]byte, error) {
+func encodeStartAuthSession(tpmKey, bindKey tpmutil.Handle, nonceCaller, secret tpmutil.U16Bytes, se SessionType, sym *SymScheme, hashAlg Algorithm) ([]byte, error) {
 	ha, err := tpmutil.Pack(tpmKey, bindKey)
 	if err != nil {
 		return nil, err
@@ -847,9 +847,9 @@ func decodeStartAuthSession(in []byte) (tpmutil.Handle, []byte, error) {
 	return handle, nonce, nil
 }
 
-// StartAuthSession initializes a session object.
+// StartAuthSessionEx initializes a session object.
 // Returns session handle and the initial nonce from the TPM.
-func StartAuthSession(rw io.ReadWriter, tpmKey, bindKey tpmutil.Handle, nonceCaller, secret []byte, se SessionType, sym, hashAlg Algorithm) (tpmutil.Handle, []byte, error) {
+func StartAuthSessionEx(rw io.ReadWriter, tpmKey, bindKey tpmutil.Handle, nonceCaller, secret []byte, se SessionType, sym *SymScheme, hashAlg Algorithm) (tpmutil.Handle, []byte, error) {
 	Cmd, err := encodeStartAuthSession(tpmKey, bindKey, nonceCaller, secret, se, sym, hashAlg)
 	if err != nil {
 		return 0, nil, err
@@ -859,6 +859,12 @@ func StartAuthSession(rw io.ReadWriter, tpmKey, bindKey tpmutil.Handle, nonceCal
 		return 0, nil, err
 	}
 	return decodeStartAuthSession(resp)
+}
+
+// StartAuthSession initializes a session object.
+// Returns session handle and the initial nonce from the TPM.
+func StartAuthSession(rw io.ReadWriter, tpmKey, bindKey tpmutil.Handle, nonceCaller, secret []byte, se SessionType, sym, hashAlg Algorithm) (tpmutil.Handle, []byte, error) {
+	return StartAuthSessionEx(rw, tpmKey, bindKey, nonceCaller, secret, se, &SymScheme{Alg: sym}, hashAlg)
 }
 
 func encodeUnseal(sessionHandle, itemHandle tpmutil.Handle, password string) ([]byte, error) {


### PR DESCRIPTION
`StartAuthSession` works passing `sym` as `AlgNull` but doesn't work for other schemes like `AlgXOR`.
`StartAuthSessionEx` fix this by accepting a complete `SymScheme` definition.