### PR TITLE
tpm2: Add HashToAlgorithm

### DIFF
--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -961,9 +961,9 @@ func decodeHashValue(in *bytes.Buffer) (*HashValue, error) {
 	if err := tpmutil.UnpackBuf(in, &hv.Alg); err != nil {
 		return nil, fmt.Errorf("decoding Alg: %v", err)
 	}
-	hfn, ok := hashMapping[hv.Alg]
-	if !ok {
-		return nil, fmt.Errorf("hash algorithm not supported: 0x%x", hv.Alg)
+	hfn, err := hv.Alg.Hash()
+	if err != nil {
+		return nil, err
 	}
 	hv.Value = make(tpmutil.U16Bytes, hfn.Size())
 	if _, err := in.Read(hv.Value); err != nil {

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -74,7 +74,7 @@ func encodeTPMLPCRSelection(sel ...PCRSelection) ([]byte, error) {
 		// s[i].PCRs parameter is indexes of PCRs, convert that to set bits.
 		for _, n := range s.PCRs {
 			if n >= 8*sizeOfPCRSelect {
-				return nil,  fmt.Errorf("PCR index %d is out of range (exceeds maximum value %d)", n, 8*sizeOfPCRSelect-1)
+				return nil, fmt.Errorf("PCR index %d is out of range (exceeds maximum value %d)", n, 8*sizeOfPCRSelect-1)
 			}
 			byteNum := n / 8
 			bytePos := byte(1 << byte(n%8))


### PR DESCRIPTION
Allows conversion from a Golang crypto.Hash to a TPM2 Algorithm

Also adds SHA3 hash algorithms/mappings, and switches from a map to
an array (as we now need a bidirectional mapping).

Signed-off-by: Joe Richey <joerichey@google.com>