### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,6 @@
 # Being an admin also gives you global code ownership.
 *                   @google/go-tpm-admin
 
-# Don't add all the admins by default for most things.
-# Note that any admins can still approve any PR.
-*                   @josephlr @twitchy-jsonp
-
 # The TPM 1.2 maintainers own the TPM 1.2 files. If this is updated, the access
 # permissions to the repository should also be updated.
 /tpm/               @zaolin @flanfly @ChriMarMe @google/go-tpm-admin


### PR DESCRIPTION
Overriding the defaults messes up who can approve PRs. For example @chrisfenner and @stevenrutherford cannot approve #226 even though they are admins.

Signed-off-by: Joe Richey <joerichey@google.com>