### PR TITLE
tpm2: fix encoding of name returned by Load()

### DIFF
--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -199,12 +199,15 @@ func TestCombinedKeyTest(t *testing.T) {
 		t.Fatalf("CreateKey failed: %s", err)
 	}
 
-	keyHandle, _, err := Load(rw, parentHandle, defaultPassword, publicBlob, privateBlob)
+	keyHandle, name, err := Load(rw, parentHandle, defaultPassword, publicBlob, privateBlob)
 	if err != nil {
 		t.Fatalf("Load failed: %s", err)
 	}
 	defer FlushContext(rw, keyHandle)
 
+	if _, err := DecodeName(bytes.NewBuffer(name)); err != nil {
+		t.Errorf("DecodeName failed: %v", err)
+	}
 	if _, _, _, err := ReadPublic(rw, keyHandle); err != nil {
 		t.Fatalf("ReadPublic failed: %s", err)
 	}
@@ -225,12 +228,15 @@ func TestCombinedEndorsementTest(t *testing.T) {
 		t.Fatalf("CreateKey failed: %s", err)
 	}
 
-	keyHandle, _, err := Load(rw, parentHandle, emptyPassword, publicBlob, privateBlob)
+	keyHandle, nameData, err := Load(rw, parentHandle, emptyPassword, publicBlob, privateBlob)
 	if err != nil {
 		t.Fatalf("Load failed: %s", err)
 	}
 	defer FlushContext(rw, keyHandle)
 
+	if _, err := DecodeName(bytes.NewBuffer(nameData)); err != nil {
+		t.Errorf("DecodeName failed: %v", err)
+	}
 	_, name, _, err := ReadPublic(rw, keyHandle)
 	if err != nil {
 		t.Fatalf("ReadPublic failed: %s", err)

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -647,7 +647,13 @@ func decodeLoad(in []byte) (tpmutil.Handle, []byte, error) {
 	if _, err := tpmutil.Unpack(in, &handle, &paramSize, &name); err != nil {
 		return 0, nil, err
 	}
-	return handle, name, nil
+
+	// Re-encode the name as a TPM2B_NAME so it can be parsed by DecodeName().
+	b := &bytes.Buffer{}
+	if err := name.TPMMarshal(b); err != nil {
+		return 0, nil, err
+	}
+	return handle, b.Bytes(), nil
 }
 
 // Load loads public/private blobs into an object in the TPM.


### PR DESCRIPTION
TPM2_Load() returns a TPM2B_NAME which includes a size prefix. However,
the currently unpacking removes this. Re-encode the name value so it can
be parsed by DecodeName().

Fixes #230