### PR TITLE
Add TPM2_PolicySigned and Signature encoding

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -400,7 +400,9 @@ const (
 	TagAttestCertify  tpmutil.Tag = 0x8017
 	TagAttestQuote    tpmutil.Tag = 0x8018
 	TagAttestCreation tpmutil.Tag = 0x801a
+	TagAuthSecret     tpmutil.Tag = 0x8023
 	TagHashCheck      tpmutil.Tag = 0x8024
+	TagAuthSigned     tpmutil.Tag = 0x8025
 )
 
 // StartupType instructs the TPM on how to handle its state during Shutdown or
@@ -470,6 +472,7 @@ const (
 	CmdSequenceUpdate             tpmutil.Command = 0x0000015C
 	CmdSign                       tpmutil.Command = 0x0000015D
 	CmdUnseal                     tpmutil.Command = 0x0000015E
+	CmdPolicySigned               tpmutil.Command = 0x00000160
 	CmdContextLoad                tpmutil.Command = 0x00000161
 	CmdContextSave                tpmutil.Command = 0x00000162
 	CmdECDHKeyGen                 tpmutil.Command = 0x00000163


### PR DESCRIPTION
In this PR:
* Support TPM2_PolicySigned and Signature encoding. 
* Change PolicySecret to support zero expiry and return the timeout value defined in Part 3 of the spec (rather than throwing it away).
  * This is a __breaking__ change 
  * 2 call sites of note:
    * https://github.com/google/go-tpm-tools/blob/master/client/session.go#L71
    * https://github.com/google/go-attestation/blob/master/attest/wrapped_tpm20.go#L453
* Test this functionality, including against different expiry values.


Split out ComputeAuthTimeout bug reproducer in #261