### PR TITLE
Remove go-cmp dependancy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/google/go-tpm
 go 1.12
 
 require (
-	github.com/google/go-cmp v0.5.4
 	github.com/google/go-tpm-tools v0.2.0
 	golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d
 )

--- a/go.sum
+++ b/go.sum
@@ -47,9 +47,8 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
-github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-tpm v0.1.2-0.20190725015402-ae6dd98980d4/go.mod h1:H9HbmUG2YgV/PHITkO7p6wxEEj/v5nlsVWIwumwH2NI=
 github.com/google/go-tpm v0.3.0/go.mod h1:iVLWvrPp/bHeEkxTFi9WG6K9w0iy2yIszHwZGHPbzAw=
 github.com/google/go-tpm-tools v0.0.0-20190906225433-1614c142f845/go.mod h1:AVfHadzbdzHo54inR2x1v640jdi1YSi3NauM2DUsxk0=

--- a/tpm2/encoding_test.go
+++ b/tpm2/encoding_test.go
@@ -24,7 +24,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-tpm/tpmutil"
 )
 
@@ -515,7 +514,9 @@ func TestTPMLDigestDecode(t *testing.T) {
 		t.Errorf("DecodeTPMDigest(b) failed: %v", err)
 	}
 
-	if !cmp.Equal(want, got) {
+	if len(got.Digests) != len(want.Digests) ||
+		!bytes.Equal(got.Digests[0], want.Digests[0]) ||
+		!bytes.Equal(got.Digests[1], want.Digests[1]) {
 		t.Errorf("Digests are not the same.\n Have:\n %v\n - Want:\n %v", got.Digests, want.Digests)
 	}
 }


### PR DESCRIPTION
This is part of a general effor to cleanup the go.mod/go.sum files

Signed-off-by: Joe Richey <joerichey@google.com>