### PR TITLE
Added NVReadLockEx, NVWriteLockEx and changed NVReadEx to support authorization flexibility

### DIFF
--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -32,7 +32,6 @@ import (
 	"testing"
 
 	"github.com/google/go-tpm-tools/simulator"
-	"github.com/google/go-tpm/tpm2"
 	. "github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 )
@@ -1443,14 +1442,14 @@ func TestNVReadWriteAndLockWithPCR(t *testing.T) {
 	}
 
 	// startAuthSession for getting policy digest
-	createPolicySession, _, err := tpm2.StartAuthSession(
+	createPolicySession, _, err := StartAuthSession(
 		rw,               /*rw io.ReadWriter*/
-		tpm2.HandleNull,  /*tpmKey tpmutil.Handle*/
-		tpm2.HandleNull,  /*bindKey tpmutil.Handle*/
+		HandleNull,       /*tpmKey tpmutil.Handle*/
+		HandleNull,       /*bindKey tpmutil.Handle*/
 		make([]byte, 16), /*nonceCaller []byte*/
 		nil,              /*secret []byte*/
 		SessionTrial,     /*se SessionType*/
-		tpm2.AlgNull,     /*sym Algorithm*/
+		AlgNull,          /*sym Algorithm*/
 		AlgSHA256)        /*hashAlg Algorithm*/
 
 	if err != nil {
@@ -1470,20 +1469,20 @@ func TestNVReadWriteAndLockWithPCR(t *testing.T) {
 	}
 
 	// Define space in NV storage and clean up afterwards or subsequent runs will fail.
-	nvPub := tpm2.NVPublic{
+	nvPub := NVPublic{
 		NVIndex:    idx,
 		NameAlg:    AlgSHA256,
 		Attributes: attr,
 		AuthPolicy: authPolicy,
 		DataSize:   uint16(len(data)),
 	}
-	authArea := tpm2.AuthCommand{
-		Session:    tpm2.HandlePasswordSession,
-		Attributes: tpm2.AttrContinueSession,
+	authArea := AuthCommand{
+		Session:    HandlePasswordSession,
+		Attributes: AttrContinueSession,
 		Auth:       []byte(emptyPassword),
 	}
 	// create NV index
-	if err := tpm2.NVDefineSpaceEx(rw,
+	if err := NVDefineSpaceEx(rw,
 		HandleOwner,
 		emptyPassword,
 		nvPub,
@@ -1500,7 +1499,7 @@ func TestNVReadWriteAndLockWithPCR(t *testing.T) {
 		t.Fatalf("StartAuthSession failed: %v", err)
 	}
 	defer func() {
-		if err := tpm2.FlushContext(rw, sessHandle); err != nil {
+		if err := FlushContext(rw, sessHandle); err != nil {
 			t.Errorf("Unable to flush the session %v", err)
 		}
 	}()
@@ -1509,9 +1508,9 @@ func TestNVReadWriteAndLockWithPCR(t *testing.T) {
 		t.Errorf("PolicyPCR failed: %v", err)
 	}
 
-	authArea = tpm2.AuthCommand{
+	authArea = AuthCommand{
 		Session:    sessHandle,
-		Attributes: tpm2.AttrContinueSession,
+		Attributes: AttrContinueSession,
 	}
 
 	// Write into the NV entity if authorization is right
@@ -1525,7 +1524,7 @@ func TestNVReadWriteAndLockWithPCR(t *testing.T) {
 		t.Fatalf("StartAuthSession failed: %v", err)
 	}
 	defer func() {
-		if err := tpm2.FlushContext(rw, wrongSessHandle); err != nil {
+		if err := FlushContext(rw, wrongSessHandle); err != nil {
 			t.Errorf("Unable to flush the session %v", err)
 		}
 	}()
@@ -1533,9 +1532,9 @@ func TestNVReadWriteAndLockWithPCR(t *testing.T) {
 	if err := PolicyPCR(rw, wrongSessHandle, nil /*expectedDigest*/, wrongSel); err != nil {
 		t.Errorf("PolicyPCR failed: %v", err)
 	}
-	wrongAuthArea := tpm2.AuthCommand{
+	wrongAuthArea := AuthCommand{
 		Session:    wrongSessHandle,
-		Attributes: tpm2.AttrContinueSession,
+		Attributes: AttrContinueSession,
 	}
 
 	// Write into the NV entity with wrong Policy

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1334,8 +1334,8 @@ func NVWriteLock(rw io.ReadWriter, owner, handle tpmutil.Handle, authString stri
 }
 
 // NVWriteLockEx does the same as NVWriteLock except accepting AuthCommand for more authorization flexibility
-func NVWriteLockEx(rw io.ReadWriter, owner, handle tpmutil.Handle, authArea AuthCommand) error {
-	Cmd, err := encodeLockNV(owner, handle, authArea)
+func NVWriteLockEx(rw io.ReadWriter, authHandle, handle tpmutil.Handle, authArea AuthCommand) error {
+	Cmd, err := encodeLockNV(authHandle, handle, authArea)
 	if err != nil {
 		return err
 	}
@@ -1472,8 +1472,8 @@ func NVReadLock(rw io.ReadWriter, owner, handle tpmutil.Handle, authString strin
 }
 
 // NVReadLockEx does the same as NVReadLock except accepting AuthCommand for more authorization flexibility
-func NVReadLockEx(rw io.ReadWriter, owner, handle tpmutil.Handle, authArea AuthCommand) error {
-	Cmd, err := encodeLockNV(owner, handle, authArea)
+func NVReadLockEx(rw io.ReadWriter, authHandle, handle tpmutil.Handle, authArea AuthCommand) error {
+	Cmd, err := encodeLockNV(authHandle, handle, authArea)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Usecase: 
When the disk encryption key is saved in the NV entity, the key can be read during the boot process if the PCRs values are as expected. OS can lock the entity after reading the encryption key to prevent accessing the secret during runtime.

Changes:
- Added NVWriteLockEx, NVReadLockEx, and changed encodeLockNV to support authorization flexibility like Policy PCR.
- Changed encodeNVRead and NVReadEx to support more authorization methods, instead of being limited to the owner's password.
- Changed NVReadEx to enable the user to define the number of octets to be read.
- Added a testcase,TestNVReadWriteAndLockWithPCR, in order to test the features