### PR TITLE
Add ComputeAuthTimeout expiry overflow reproducer

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -400,7 +400,9 @@ const (
 	TagAttestCertify  tpmutil.Tag = 0x8017
 	TagAttestQuote    tpmutil.Tag = 0x8018
 	TagAttestCreation tpmutil.Tag = 0x801a
+	TagAuthSecret     tpmutil.Tag = 0x8023
 	TagHashCheck      tpmutil.Tag = 0x8024
+	TagAuthSigned     tpmutil.Tag = 0x8025
 )
 
 // StartupType instructs the TPM on how to handle its state during Shutdown or
@@ -470,6 +472,7 @@ const (
 	CmdSequenceUpdate             tpmutil.Command = 0x0000015C
 	CmdSign                       tpmutil.Command = 0x0000015D
 	CmdUnseal                     tpmutil.Command = 0x0000015E
+	CmdPolicySigned               tpmutil.Command = 0x00000160
 	CmdContextLoad                tpmutil.Command = 0x00000161
 	CmdContextSave                tpmutil.Command = 0x00000162
 	CmdECDHKeyGen                 tpmutil.Command = 0x00000163

--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -23,10 +23,12 @@ import (
 	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/sha256"
+	"encoding/binary"
 	"flag"
 	"fmt"
 	"hash"
 	"io"
+	"math/big"
 	"reflect"
 	"strings"
 	"testing"
@@ -1180,6 +1182,69 @@ func TestEncodeDecodePublicDefaultRSAExponent(t *testing.T) {
 		t.Logf("\tGot:  %+v", d)
 		t.Logf("\tWant: %+v", p)
 	}
+}
+
+func TestEncodeDecodeSignature(t *testing.T) {
+	randRSASig := func() []byte {
+		// Key size 2048 bits
+		var size uint16 = 256
+		sizeU16 := make([]byte, 2)
+		binary.BigEndian.PutUint16(sizeU16, size)
+		key := make([]byte, size)
+		rand.Read(key)
+		return append(sizeU16, key...)
+	}
+
+	run := func(t *testing.T, s Signature) {
+		e, err := s.Encode()
+		if err != nil {
+			t.Fatalf("Signature{%+v}.Encode() returned error: %v", s, err)
+		}
+		d, err := DecodeSignature(bytes.NewBuffer(e))
+		if err != nil {
+			t.Fatalf("DecodeSignature{%v} returned error: %v", e, err)
+		}
+		if !reflect.DeepEqual(s, *d) {
+			t.Errorf("got decoded value:\n%v\nwant:\n%v", d, s)
+		}
+	}
+	t.Run("RSASSA", func(t *testing.T) {
+		run(t, Signature{
+			Alg: AlgRSASSA,
+			RSA: &SignatureRSA{
+				HashAlg:   AlgSHA256,
+				Signature: randRSASig(),
+			},
+		})
+	})
+	t.Run("RSAPSS", func(t *testing.T) {
+		run(t, Signature{
+			Alg: AlgRSAPSS,
+			RSA: &SignatureRSA{
+				HashAlg:   AlgSHA256,
+				Signature: randRSASig(),
+			},
+		})
+	})
+	t.Run("ECDSA", func(t *testing.T) {
+		// Key size 256 bits
+		size := 32
+		randBytes := make([]byte, size)
+		rand.Read(randBytes)
+		r := big.NewInt(0).SetBytes(randBytes)
+
+		rand.Read(randBytes)
+		s := big.NewInt(0).SetBytes(randBytes)
+
+		run(t, Signature{
+			Alg: AlgECDSA,
+			ECC: &SignatureECC{
+				HashAlg: AlgSHA256,
+				R:       r,
+				S:       s,
+			},
+		})
+	})
 }
 
 func TestCreateKeyWithSensitive(t *testing.T) {

--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -79,8 +79,32 @@ var (
 			ExponentRaw: 1<<16 + 1,
 		},
 	}
-	defaultPassword = "\x01\x02\x03\x04"
-	emptyPassword   = ""
+	defaultPassword        = "\x01\x02\x03\x04"
+	emptyPassword          = ""
+	defaultRsaSignerParams = Public{
+		Type:       AlgRSA,
+		NameAlg:    AlgSHA256,
+		Attributes: FlagSign | FlagSensitiveDataOrigin | FlagUserWithAuth,
+		RSAParameters: &RSAParams{
+			Sign: &SigScheme{
+				Alg:  AlgRSASSA,
+				Hash: AlgSHA256,
+			},
+			KeyBits: 2048,
+		},
+	}
+	defaultEccSignerParams = Public{
+		Type:       AlgECC,
+		NameAlg:    AlgSHA256,
+		Attributes: FlagSign | FlagSensitiveDataOrigin | FlagUserWithAuth,
+		ECCParameters: &ECCParams{
+			Sign: &SigScheme{
+				Alg:  AlgECDSA,
+				Hash: AlgSHA256,
+			},
+			CurveID: CurveNISTP256,
+		},
+	}
 )
 
 func min(a, b int) int {
@@ -1494,15 +1518,87 @@ func TestPolicySecret(t *testing.T) {
 	rw := openTPM(t)
 	defer rw.Close()
 
+	_, _ = testPolicySecret(t, rw, 0)
+}
+
+func testPolicySecret(t *testing.T, rw io.ReadWriter, expiration int32) ([]byte, *Ticket) {
 	sessHandle, _, err := StartAuthSession(rw, HandleNull, HandleNull, make([]byte, 16), nil, SessionPolicy, AlgNull, AlgSHA256)
 	if err != nil {
 		t.Fatalf("StartAuthSession() failed: %v", err)
 	}
 	defer FlushContext(rw, sessHandle)
 
-	if _, err := PolicySecret(rw, HandleEndorsement, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession}, sessHandle, nil, nil, nil, 0); err != nil {
+	timeout, tkt, err := PolicySecret(rw, HandleEndorsement, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession}, sessHandle, nil, nil, nil, expiration)
+	if err != nil {
 		t.Fatalf("PolicySecret() failed: %v", err)
 	}
+	return timeout, tkt
+}
+
+func TestPolicySigned(t *testing.T) {
+	rw := openTPM(t)
+	defer rw.Close()
+
+	var nullTicket = Ticket{Type: TagAuthSigned, Hierarchy: HandleNull}
+	signers := map[string]Public{
+		"RSA": defaultRsaSignerParams,
+		"ECC": defaultEccSignerParams,
+	}
+
+	expirations := []int32{math.MinInt32, math.MinInt32 + 1, -1, 0, 1, math.MaxInt32}
+	for _, expiration := range expirations {
+		for signerType, params := range signers {
+			t.Run(t.Name()+signerType+fmt.Sprint(expiration), func(t *testing.T) {
+				_, tkt := testPolicySigned(t, rw, expiration, params)
+				if expiration < 0 && len(tkt.Digest) == 0 {
+					t.Fatalf("Got empty ticket digest, expected ticket with auth expiry")
+				} else if expiration >= 0 && !reflect.DeepEqual(*tkt, nullTicket) {
+					t.Fatalf("Got ticket with non-empty digest, expected NULL ticket")
+				}
+			})
+		}
+	}
+}
+
+func testPolicySigned(t *testing.T, rw io.ReadWriter, expiration int32, signerParams Public) ([]byte, *Ticket) {
+	handle, _, err := CreatePrimary(rw, HandleOwner, PCRSelection{}, emptyPassword, emptyPassword, signerParams)
+	if err != nil {
+		t.Fatalf("CreatePrimary() failed: %s", err)
+	}
+	defer FlushContext(rw, handle)
+
+	sessHandle, nonce, err := StartAuthSession(rw, HandleNull, HandleNull, make([]byte, 16), nil, SessionPolicy, AlgNull, AlgSHA256)
+	if err != nil {
+		t.Fatalf("StartAuthSession() failed: %v", err)
+	}
+	defer FlushContext(rw, sessHandle)
+
+	// Sign the hash of the command parameters, as described in the TPM 2.0 spec, Part 3, Section 23.3.
+	// We only use expiration here.
+	expBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(expBytes, uint32(expiration))
+
+	// TPM2.0 spec, Revision 1.38, Part 3 nonce must be present if expiration is non-zero.
+	// aHash ≔ HauthAlg(nonceTPM || expiration || cpHashA || policyRef)
+	toDigest := append(nonce, expBytes...)
+
+	digest := sha256.Sum256(toDigest)
+
+	sig, err := Sign(rw, handle, emptyPassword, digest[:], nil, nil)
+	if err != nil {
+		t.Fatalf("Sign failed: %s", err)
+	}
+
+	signature, err := sig.Encode()
+	if err != nil {
+		t.Fatalf("Encode() failed: %v", err)
+	}
+
+	timeout, tkt, err := PolicySigned(rw, handle, sessHandle, nonce, nil, nil, expiration, signature)
+	if err != nil {
+		t.Fatalf("PolicySigned() failed: %v", err)
+	}
+	return timeout, tkt
 }
 
 func TestQuote(t *testing.T) {


### PR DESCRIPTION
(Split off from #237 to allow merging the new functionality in)

The Microsoft TPM2 and IBM SW TPM simulator both use an absolute
value method of `expiration = -expiration` in ComputeAuthTimeout.

As abs(min Int32) cannot be represented an an int32, this expression evaluates to min Int32.

See https://github.com/microsoft/ms-tpm-20-ref/blob/b94f9f92c579b723a16be72a69efbbf9c35ce44e/TPMCmd/tpm/src/command/EA/Policy_spt.c#L189

The function goes on to cast expiration to UINT64. This can either
be sign-extended or zero-extended, which is undefined behavior.