### PR TITLE
Add PCRReset command for tpm2

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -454,6 +454,7 @@ const (
 	CmdDictionaryAttackLockReset  tpmutil.Command = 0x00000139
 	CmdDictionaryAttackParameters tpmutil.Command = 0x0000013A
 	CmdPCREvent                   tpmutil.Command = 0x0000013C
+	CmdPCRReset                   tpmutil.Command = 0x0000013D
 	CmdSequenceComplete           tpmutil.Command = 0x0000013E
 	CmdStartup                    tpmutil.Command = 0x00000144
 	CmdShutdown                   tpmutil.Command = 0x00000145


### PR DESCRIPTION
Add a command to reset a PCR

This will allow us to reset the debug pcr 16 and pcr 23 in a test that requires a clean pcr.