### PR TITLE
Add a lot of policy and NV commands to TPMDirect

### DIFF
--- a/direct/structures/internal/constants.go
+++ b/direct/structures/internal/constants.go
@@ -317,11 +317,17 @@ const (
 	TPMSTFuManifest         TPMST = 0x8029
 )
 
+// TPMSU values come from Part 2: Structures, section  6.10.
+const (
+	TPMSUClear TPMSU = 0x0000
+	TPMSUState TPMSU = 0x0001
+)
+
 // TPMSE values come from Part 2: Structures, section 6.11.
 const (
 	TPMSEHMAC   TPMSE = 0x00
 	TPMSEPolicy TPMSE = 0x01
-	TPMXETrial  TPMSE = 0x03
+	TPMSETrial  TPMSE = 0x03
 )
 
 // TPMCap values come from Part 2: Structures, section 6.12.
@@ -561,4 +567,27 @@ const (
 	TPMRHEndorsement TPMHandle = 0x4000000B
 	TPMRHPlatform    TPMHandle = 0x4000000C
 	TPMRHPlatformNV  TPMHandle = 0x4000000D
+)
+
+// TPMNT values come from Part 2: Structures, section 13.2.
+const (
+	// contains data that is opaque to the TPM that can only be modified
+	// using TPM2_NV_Write().
+	TPMNTOrdinary TPMNT = 0x0
+	// contains an 8-octet value that is to be used as a counter and can
+	// only be modified with TPM2_NV_Increment()
+	TPMNTCounter TPMNT = 0x1
+	// contains an 8-octet value to be used as a bit field and can only be
+	// modified with TPM2_NV_SetBits().
+	TPMNTBits TPMNT = 0x2
+	// contains a digest-sized value used like a PCR. The Index can only be
+	// modified using TPM2_NV_Extend(). The extend will use the nameAlg of
+	// the Index.
+	TPMNTExtend TPMNT = 0x4
+	// contains pinCount that increments on a PIN authorization failure and
+	// a pinLimit
+	TPMNTPinFail TPMNT = 0x8
+	// contains pinCount that increments on a PIN authorization success and
+	// a pinLimit
+	TPMNTPinPass TPMNT = 0x9
 )

--- a/direct/structures/internal/errors.go
+++ b/direct/structures/internal/errors.go
@@ -10,6 +10,10 @@ type errorDesc struct {
 }
 
 var fmt0Descs = map[TPMRC]errorDesc{
+	TPMRCInitialize: errorDesc{
+		name:        "TPM_RC_INITIALIZE",
+		description: "TPM not initialized by TPM2_Startup or already initialized",
+	},
 	TPMRCFailure: errorDesc{
 		name:        "TPM_RC_FAILURE",
 		description: "commands not being accepted because of a TPM failure",

--- a/direct/structures/tpm/constants.go
+++ b/direct/structures/tpm/constants.go
@@ -47,7 +47,7 @@ const (
 	AlgECB          = internal.TPMAlgECB
 )
 
-// ECCCurve = internal.TPMECCCurve
+// ECCCurve values come from Part 2: Structures, section 6.4.
 const (
 	ECCNone     = internal.TPMECCNone
 	ECCNistP192 = internal.TPMECCNistP192
@@ -60,7 +60,7 @@ const (
 	ECCSM2P256  = internal.TPMECCSM2P256
 )
 
-// CC = internal.TPMCC
+// CC values come from Part 2: Structures, section 6.5.2.
 const (
 	CCNVUndefineSpaceSpecial     = internal.TPMCCNVUndefineSpaceSpecial
 	CCEvictControl               = internal.TPMCCEvictControl
@@ -183,7 +183,7 @@ const (
 	CCACTSetTimeout              = internal.TPMCCACTSetTimeout
 )
 
-// RC = internal.TPMRC
+// RC values come from Part 2: Structures, section 6.6.3.
 const (
 	RCSuccess = internal.TPMRCSuccess
 	// FMT0 error codes
@@ -286,7 +286,7 @@ const (
 	RCNVUnavailable  = internal.TPMRCNVUnavailable
 )
 
-// ST = internal.TPMST
+// ST values come from Part 2: Structures, section  6.9.
 const (
 	STRspCommand         = internal.TPMSTRspCommand
 	STNull               = internal.TPMSTNull
@@ -308,14 +308,20 @@ const (
 	STFuManifest         = internal.TPMSTFuManifest
 )
 
-// SE = internal.TPMSE
+// SU values come from Part 2: Structures, section  6.10.
+const (
+	SUClear = internal.TPMSUClear
+	SUState = internal.TPMSUState
+)
+
+// SE values come from Part 2: Structures, section 6.11.
 const (
 	SEHMAC   = internal.TPMSEHMAC
 	SEPolicy = internal.TPMSEPolicy
-	XETrial  = internal.TPMXETrial
+	SETrial  = internal.TPMSETrial
 )
 
-// Cap = internal.TPMCap
+// Cap values come from Part 2: Structures, section 6.12.
 const (
 	CapAlgs          = internal.TPMCapAlgs
 	CapHandles       = internal.TPMCapHandles
@@ -503,4 +509,27 @@ const (
 	RHEndorsement = internal.TPMRHEndorsement
 	RHPlatform    = internal.TPMRHPlatform
 	RHPlatformNV  = internal.TPMRHPlatformNV
+)
+
+// NT values come from Part 2: Structures, section 13.2.
+const (
+	// contains data that is opaque to the TPM that can only be modified
+	// using TPM2_NV_Write().
+	NTOrdinary = internal.TPMNTOrdinary
+	// contains an 8-octet value that is to be used as a counter and can
+	// only be modified with TPM2_NV_Increment()
+	NTCounter = internal.TPMNTCounter
+	// contains an 8-octet value to be used as a bit field and can only be
+	// modified with TPM2_NV_SetBits().
+	NTBits = internal.TPMNTBits
+	// contains a digest-sized value used like a PCR. The Index can only be
+	// modified using TPM2_NV_Extend(). The extend will use the nameAlg of
+	// the Index.
+	NTExtend = internal.TPMNTExtend
+	// contains pinCount that increments on a PIN authorization failure and
+	// a pinLimit
+	NTPinFail = internal.TPMNTPinFail
+	// contains pinCount that increments on a PIN authorization success and
+	// a pinLimit
+	NTPinPass = internal.TPMNTPinPass
 )

--- a/direct/structures/tpm/tpm.go
+++ b/direct/structures/tpm/tpm.go
@@ -69,6 +69,10 @@ type Fmt1Error = internal.TPMFmt1Error
 // See definition in Part 2: Structures, section 6.9.
 type ST = internal.TPMST
 
+// SU represents a TPM_SU.
+// See definition in Part 2: Structures, section 6.10.
+type SU = internal.TPMSU
+
 // SE represents a TPM_SE.
 // See definition in Part 2: Structures, section 6.11.
 type SE = internal.TPMSE
@@ -88,3 +92,7 @@ type PTPCR = internal.TPMPTPCR
 // Handle represents a TPM_HANDLE.
 // See definition in Part 2: Structures, section 7.1.
 type Handle = internal.TPMHandle
+
+// NT represents a TPM_NT.
+// See definition in Part 2: Structures, section 13.4.
+type NT = internal.TPMNT

--- a/direct/structures/tpm2b/tpm2b.go
+++ b/direct/structures/tpm2b/tpm2b.go
@@ -29,6 +29,10 @@ type Timeout = internal.TPM2BTimeout
 // See definition in Part 2: Structures, section 10.4.5.
 type Auth = internal.TPM2BAuth
 
+// TPM2BMaxNVBuffer represents a TPM2B_MAX_NV_BUFFER.
+// See definition in Part 2: Structures, section 10.4.9.
+type MaxNVBuffer = internal.TPM2BMaxNVBuffer
+
 // Name represents a TPM2B_NAME.
 // See definition in Part 2: Structures, section 10.5.3.
 // NOTE: This structure does not contain a TPMUName, because that union
@@ -69,6 +73,10 @@ type Public = internal.TPM2BPublic
 // Private represents a TPM2B_PRIVATE.
 // See definition in Part 2: Structures, section 12.3.7.
 type Private = internal.TPM2BPrivate
+
+// NVPublic represents a TPM2B_NV_PUBLIC.
+// See definition in Part 2: Structures, section 13.6.
+type NVPublic = internal.TPM2BNVPublic
 
 // CreationData represents a TPM2B_CREATION_DATA.
 // See definition in Part 2: Structures, section 15.2.

--- a/direct/structures/tpm2b/tpm2b.go
+++ b/direct/structures/tpm2b/tpm2b.go
@@ -46,6 +46,18 @@ type Name = internal.TPM2BName
 // For ergonomics, pretend that TPM2B_Attest wraps a TPMS_Attest just like other 2Bs.
 type Attest = internal.TPM2BAttest
 
+// SymKey represents a TPM2B_SYM_KEY.
+// See definition in Part 2: Structures, section 11.1.8.
+type SymKey = internal.TPM2BSymKey
+
+// Label represents a TPM2B_LABEL.
+// See definition in Part 2: Structures, section 11.1.10.
+type Label = internal.TPM2BLabel
+
+// Derive represents a TPM2B_DERIVE.
+// See definition in Part 2: Structures, section 11.1.12.
+type Derive = internal.TPM2BDerive
+
 // SensitiveData represents a TPM2B_SENSITIVE_DATA.
 // See definition in Part 2: Structures, section 11.1.14.
 type SensitiveData = internal.TPM2BSensitiveData
@@ -58,6 +70,10 @@ type SensitiveCreate = internal.TPM2BSensitiveCreate
 // See definition in Part 2: Structures, section 11.2.4.5.
 type PublicKeyRSA = internal.TPM2BPublicKeyRSA
 
+// PrivateKeyRSA representsa a TPM2B_PRIVATE_KEY_RSA.
+// See definition in Part 2: Structures, section 11.2.4.7.
+type PrivateKeyRSA = internal.TPM2BPrivateKeyRSA
+
 // ECCParameter represents a TPM2B_ECC_PARAMETER.
 // See definition in Part 2: Structures, section 11.2.5.1.
 type ECCParameter = internal.TPM2BECCParameter
@@ -69,6 +85,14 @@ type EncryptedSecret = internal.TPM2BEncryptedSecret
 // Public represents a TPM2B_PUBLIC.
 // See definition in Part 2: Structures, section 12.2.5.
 type Public = internal.TPM2BPublic
+
+// Template represents a TPM2B_TEMPLATE.
+// See definition in Part 2: Structures, section 12.2.6.
+type Template = internal.TPM2BTemplate
+
+// Sensitive represents a TPM2B_SENSITIVE.
+// See definition in Part 2: Structures, section 12.3.3.
+type Sensitive = internal.TPM2BSensitive
 
 // Private represents a TPM2B_PRIVATE.
 // See definition in Part 2: Structures, section 12.3.7.

--- a/direct/structures/tpma/tpma.go
+++ b/direct/structures/tpma/tpma.go
@@ -32,3 +32,7 @@ type CC = internal.TPMACC
 // ACT represents a TPMA_ACT.
 // See definition in Part 2: Structures, section 8.12.
 type ACT = internal.TPMAACT
+
+// NV represents a TPMA_NV.
+// See definition in Part 2: Structures, section 13.4.
+type NV = internal.TPMANV

--- a/direct/structures/tpmi/tpmi.go
+++ b/direct/structures/tpmi/tpmi.go
@@ -38,6 +38,58 @@ type DHContext = internal.TPMIDHContext
 // See definition in Part 2: Structures, section 9.13.
 type RHHierarchy = internal.TPMIRHHierarchy
 
+// RHEnables represents a TPMI_RH_ENABLES.
+// See definition in Part 2: Structures, section 9.14.
+type RHEnables = internal.TPMIRHEnables
+
+// RHHierarchyAuth represents a TPMI_RH_HIERARCHY_AUTH.
+// See definition in Part 2: Structures, section 9.15.
+type RHHierarchyAuth = internal.TPMIRHHierarchyAuth
+
+// RHHierarchyPolicy represents a TPMI_RH_HIERARCHY_POLICY.
+// See definition in Part 2: Structures, section 9.16.
+type RHHierarchyPolicy = internal.TPMIRHHierarchyPolicy
+
+// RHPlatform represents a TPMI_RH_PLATFORM.
+// See definition in Part 2: Structures, section 9.17.
+type RHPlatform = internal.TPMIRHPlatform
+
+// RHOwner represents a TPMI_RH_OWNER.
+// See definition in Part 2: Structures, section 9.18.
+type RHOwner = internal.TPMIRHOwner
+
+// RHEndorsement represents a TPMI_RH_ENDORSEMENT.
+// See definition in Part 2: Structures, section 9.19.
+type RHEndorsement = internal.TPMIRHEndorsement
+
+// RHProvision represents a TPMI_RH_PROVISION.
+// See definition in Part 2: Structures, section 9.20.
+type RHProvision = internal.TPMIRHProvision
+
+// RHClear represents a TPMI_RH_CLEAR.
+// See definition in Part 2: Structures, section 9.21.
+type RHClear = internal.TPMIRHClear
+
+// RHNVAuth represents a TPMI_RH_NV_AUTH.
+// See definition in Part 2: Structures, section 9.22.
+type RHNVAuth = internal.TPMIRHNVAuth
+
+// RHLockout represents a TPMI_RH_LOCKOUT.
+// See definition in Part 2: Structures, section 9.23.
+type RHLockout = internal.TPMIRHLockout
+
+// RHNVIndex represents a TPMI_RH_NV_INDEX.
+// See definition in Part 2: Structures, section 9.24.
+type RHNVIndex = internal.TPMIRHNVIndex
+
+// RHAC represents a TPMI_RH_AC.
+// See definition in Part 2: Structures, section 9.25.
+type RHAC = internal.TPMIRHAC
+
+// RHACT represents a TPMI_RH_ACT.
+// See definition in Part 2: Structures, section 9.26.
+type RHACT = internal.TPMIRHACT
+
 // AlgHash represents a TPMI_ALG_HASH.
 // See definition in Part 2: Structures, section 9.27.
 type AlgHash = internal.TPMIAlgHash

--- a/direct/structures/tpms/tpms.go
+++ b/direct/structures/tpms/tpms.go
@@ -175,6 +175,10 @@ type RSAParms = internal.TPMSRSAParms
 // See definition in Part 2: Structures, section 12.2.3.6.
 type ECCParms = internal.TPMSECCParms
 
+// NVPublic represents a TPMS_NV_PUBLIC.
+// See definition in Part 2: Structures, section 13.5.
+type NVPublic = internal.TPMSNVPublic
+
 // CreationData represents a TPMS_CREATION_DATA.
 // See definition in Part 2: Structures, section 15.1.
 type CreationData = internal.TPMSCreationData

--- a/direct/structures/tpms/tpms.go
+++ b/direct/structures/tpms/tpms.go
@@ -91,6 +91,10 @@ type AuthResponse = internal.TPMSAuthResponse
 // See definition in Part 2: Structures, section 11.1.9.
 type SymCipherParms = internal.TPMSSymCipherParms
 
+// Derive represents a TPMS_DERIVE.
+// See definition in Part 2: Structures, section 11.1.11.
+type Derive = internal.TPMSDerive
+
 // SensitiveCreate represents a TPMS_SENSITIVE_CREATE.
 // See definition in Part 2: Structures, section 11.1.15.
 type SensitiveCreate = internal.TPMSSensitiveCreate
@@ -163,7 +167,7 @@ type SignatureRSA = internal.TPMSSignatureRSA
 // See definition in Part 2: Structures, section 11.3.2.
 type SignatureECC = internal.TPMSSignatureECC
 
-// KeyedHashParms represents a TPMS_KEYED_HASH_PARMS.
+// KeyedHashParms represents a TPMS_KEYEDHASH_PARMS.
 // See definition in Part 2: Structures, section 12.2.3.3.
 type KeyedHashParms = internal.TPMSKeyedHashParms
 

--- a/direct/structures/tpmt/tpmt.go
+++ b/direct/structures/tpmt/tpmt.go
@@ -11,6 +11,10 @@ type HA = internal.TPMTHA
 // See definition in Part 2: Structures, section 10.7.3.
 type TKCreation = internal.TPMTTKCreation
 
+// TVerified represents a TPMT_TK_Verified.
+// See definition in Part 2: Structures, section 10.7.4.
+type TKVerified = internal.TPMTTKVerified
+
 // TKAuth represents a TPMT_TK_AUTH.
 // See definition in Part 2: Structures, section 10.7.5.
 type TKAuth = internal.TPMTTKAuth

--- a/direct/structures/tpmt/tpmt.go
+++ b/direct/structures/tpmt/tpmt.go
@@ -54,3 +54,12 @@ type Signature = internal.TPMTSignature
 // Public represents a TPMT_PUBLIC.
 // See definition in Part 2: Structures, section 12.2.4.
 type Public = internal.TPMTPublic
+
+// Template represents a TPMT_TEMPLATE. It is not defined in the spec.
+// It represents the alternate form of TPMT_PUBLIC for TPM2B_TEMPLATE as
+// described in Part 2: Structures, 12.2.6.
+type Template = internal.TPMTTemplate
+
+// Sensitive represents a TPMT_SENSITIVE.
+// See definition in Part 2: Structures, section 12.3.2.4.
+type Sensitive = internal.TPMTSensitive

--- a/direct/structures/tpmu/tpmu.go
+++ b/direct/structures/tpmu/tpmu.go
@@ -3,10 +3,6 @@ package tpmu
 
 import "github.com/google/go-tpm/direct/structures/internal"
 
-// HA represents a TPMU_HA.
-// See definition in Part 2: Structures, section 10.3.1.
-type HA = internal.TPMUHA
-
 // Capabilities represents a TPMU_CAPABILITIES.
 // See definition in Part 2: Structures, section 10.10.1.
 type Capabilities = internal.TPMUCapabilities

--- a/direct/structures/tpmu/tpmu.go
+++ b/direct/structures/tpmu/tpmu.go
@@ -23,6 +23,10 @@ type SymMode = internal.TPMUSymMode
 // See definition in Part 2: Structures, section 11.1.5.
 type SymDetails = internal.TPMUSymDetails
 
+// SensitiveCreate represents a TPMU_SENSITIVE_CREATE.
+// See definition in Part 2: Structures, section 11.1.13.
+type SensitiveCreate = internal.TPMUSensitiveCreate
+
 // SchemeKeyedHash represents a TPMU_SCHEME_KEYEDHASH.
 // See definition in Part 2: Structures, section 11.1.22.
 type SchemeKeyedHash = internal.TPMUSchemeKeyedHash
@@ -50,3 +54,12 @@ type PublicID = internal.TPMUPublicID
 // PublicParms represents a TPMU_PUBLIC_PARMS.
 // See definition in Part 2: Structures, section 12.2.3.7.
 type PublicParms = internal.TPMUPublicParms
+
+// Template represents the possible contents of a TPM2B_Template. It is not
+// defined or named in the spec, which instead describes how its contents may
+// differ in the case of CreateLoaded with a derivation parent.
+type Template = internal.TPMUTemplate
+
+// SensitiveComposite represents a TPMU_SENSITIVE_COMPOSITE.
+// See definition in Part 2: Structures, section 12.3.2.3.
+type SensitiveComposite = internal.TPMUSensitiveComposite

--- a/direct/templates/templates.go
+++ b/direct/templates/templates.go
@@ -13,186 +13,180 @@ import (
 var (
 	// RSASRKTemplate contains the TCG reference RSA-2048 SRK template.
 	// https://trustedcomputinggroup.org/wp-content/uploads/TCG-tpm.-v2.0-Provisioning-Guidance-Published-v1r1.pdf
-	RSASRKTemplate = tpm2b.Public{
-		PublicArea: tpmt.Public{
-			Type:    tpm.AlgRSA,
-			NameAlg: tpm.AlgSHA256,
-			ObjectAttributes: tpma.Object{
-				FixedTPM:             true,
-				STClear:              false,
-				FixedParent:          true,
-				SensitiveDataOrigin:  true,
-				UserWithAuth:         true,
-				AdminWithPolicy:      false,
-				NoDA:                 true,
-				EncryptedDuplication: false,
-				Restricted:           true,
-				Decrypt:              true,
-				SignEncrypt:          false,
-			},
-			Parameters: tpmu.PublicParms{
-				RSADetail: &tpms.RSAParms{
-					Symmetric: tpmt.SymDefObject{
-						Algorithm: tpm.AlgAES,
-						KeyBits: tpmu.SymKeyBits{
-							AES: helpers.NewKeyBits(128),
-						},
-						Mode: tpmu.SymMode{
-							AES: helpers.NewAlgID(tpm.AlgCFB),
-						},
+	RSASRKTemplate = tpmt.Public{
+		Type:    tpm.AlgRSA,
+		NameAlg: tpm.AlgSHA256,
+		ObjectAttributes: tpma.Object{
+			FixedTPM:             true,
+			STClear:              false,
+			FixedParent:          true,
+			SensitiveDataOrigin:  true,
+			UserWithAuth:         true,
+			AdminWithPolicy:      false,
+			NoDA:                 true,
+			EncryptedDuplication: false,
+			Restricted:           true,
+			Decrypt:              true,
+			SignEncrypt:          false,
+		},
+		Parameters: tpmu.PublicParms{
+			RSADetail: &tpms.RSAParms{
+				Symmetric: tpmt.SymDefObject{
+					Algorithm: tpm.AlgAES,
+					KeyBits: tpmu.SymKeyBits{
+						AES: helpers.NewKeyBits(128),
 					},
-					KeyBits: 2048,
+					Mode: tpmu.SymMode{
+						AES: helpers.NewAlgID(tpm.AlgCFB),
+					},
 				},
+				KeyBits: 2048,
 			},
-			Unique: tpmu.PublicID{
-				RSA: &tpm2b.PublicKeyRSA{
-					Buffer: make([]byte, 256),
-				},
+		},
+		Unique: tpmu.PublicID{
+			RSA: &tpm2b.PublicKeyRSA{
+				Buffer: make([]byte, 256),
 			},
 		},
 	}
 	// RSAEKTemplate contains the TCG reference RSA-2048 EK template.
-	RSAEKTemplate = tpm2b.Public{
-		PublicArea: tpmt.Public{
-			Type:    tpm.AlgRSA,
-			NameAlg: tpm.AlgSHA256,
-			ObjectAttributes: tpma.Object{
-				FixedTPM:             true,
-				STClear:              false,
-				FixedParent:          true,
-				SensitiveDataOrigin:  true,
-				UserWithAuth:         false,
-				AdminWithPolicy:      true,
-				NoDA:                 false,
-				EncryptedDuplication: false,
-				Restricted:           true,
-				Decrypt:              true,
-				SignEncrypt:          false,
+	RSAEKTemplate = tpmt.Public{
+		Type:    tpm.AlgRSA,
+		NameAlg: tpm.AlgSHA256,
+		ObjectAttributes: tpma.Object{
+			FixedTPM:             true,
+			STClear:              false,
+			FixedParent:          true,
+			SensitiveDataOrigin:  true,
+			UserWithAuth:         false,
+			AdminWithPolicy:      true,
+			NoDA:                 false,
+			EncryptedDuplication: false,
+			Restricted:           true,
+			Decrypt:              true,
+			SignEncrypt:          false,
+		},
+		AuthPolicy: tpm2b.Digest{
+			Buffer: []byte{
+				// tpm.2_PolicySecret(RH_ENDORSEMENT)
+				0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xB3, 0xF8,
+				0x1A, 0x90, 0xCC, 0x8D, 0x46, 0xA5, 0xD7, 0x24,
+				0xFD, 0x52, 0xD7, 0x6E, 0x06, 0x52, 0x0B, 0x64,
+				0xF2, 0xA1, 0xDA, 0x1B, 0x33, 0x14, 0x69, 0xAA,
 			},
-			AuthPolicy: tpm2b.Digest{
-				Buffer: []byte{
-					// tpm.2_PolicySecret(RH_ENDORSEMENT)
-					0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xB3, 0xF8,
-					0x1A, 0x90, 0xCC, 0x8D, 0x46, 0xA5, 0xD7, 0x24,
-					0xFD, 0x52, 0xD7, 0x6E, 0x06, 0x52, 0x0B, 0x64,
-					0xF2, 0xA1, 0xDA, 0x1B, 0x33, 0x14, 0x69, 0xAA,
-				},
-			},
-			Parameters: tpmu.PublicParms{
-				RSADetail: &tpms.RSAParms{
-					Symmetric: tpmt.SymDefObject{
-						Algorithm: tpm.AlgAES,
-						KeyBits: tpmu.SymKeyBits{
-							AES: helpers.NewKeyBits(128),
-						},
-						Mode: tpmu.SymMode{
-							AES: helpers.NewAlgID(tpm.AlgCFB),
-						},
+		},
+		Parameters: tpmu.PublicParms{
+			RSADetail: &tpms.RSAParms{
+				Symmetric: tpmt.SymDefObject{
+					Algorithm: tpm.AlgAES,
+					KeyBits: tpmu.SymKeyBits{
+						AES: helpers.NewKeyBits(128),
 					},
-					KeyBits: 2048,
+					Mode: tpmu.SymMode{
+						AES: helpers.NewAlgID(tpm.AlgCFB),
+					},
 				},
+				KeyBits: 2048,
 			},
-			Unique: tpmu.PublicID{
-				RSA: &tpm2b.PublicKeyRSA{
-					Buffer: make([]byte, 256),
-				},
+		},
+		Unique: tpmu.PublicID{
+			RSA: &tpm2b.PublicKeyRSA{
+				Buffer: make([]byte, 256),
 			},
 		},
 	}
+
 	// ECCSRKTemplate contains the TCG reference ECC-P256 SRK template.
 	// https://trustedcomputinggroup.org/wp-content/uploads/TCG-tpm.-v2.0-Provisioning-Guidance-Published-v1r1.pdf
-	ECCSRKTemplate = tpm2b.Public{
-		PublicArea: tpmt.Public{
-			Type:    tpm.AlgECC,
-			NameAlg: tpm.AlgSHA256,
-			ObjectAttributes: tpma.Object{
-				FixedTPM:             true,
-				STClear:              false,
-				FixedParent:          true,
-				SensitiveDataOrigin:  true,
-				UserWithAuth:         true,
-				AdminWithPolicy:      false,
-				NoDA:                 true,
-				EncryptedDuplication: false,
-				Restricted:           true,
-				Decrypt:              true,
-				SignEncrypt:          false,
-			},
-			Parameters: tpmu.PublicParms{
-				ECCDetail: &tpms.ECCParms{
-					Symmetric: tpmt.SymDefObject{
-						Algorithm: tpm.AlgAES,
-						KeyBits: tpmu.SymKeyBits{
-							AES: helpers.NewKeyBits(128),
-						},
-						Mode: tpmu.SymMode{
-							AES: helpers.NewAlgID(tpm.AlgCFB),
-						},
+	ECCSRKTemplate = tpmt.Public{
+		Type:    tpm.AlgECC,
+		NameAlg: tpm.AlgSHA256,
+		ObjectAttributes: tpma.Object{
+			FixedTPM:             true,
+			STClear:              false,
+			FixedParent:          true,
+			SensitiveDataOrigin:  true,
+			UserWithAuth:         true,
+			AdminWithPolicy:      false,
+			NoDA:                 true,
+			EncryptedDuplication: false,
+			Restricted:           true,
+			Decrypt:              true,
+			SignEncrypt:          false,
+		},
+		Parameters: tpmu.PublicParms{
+			ECCDetail: &tpms.ECCParms{
+				Symmetric: tpmt.SymDefObject{
+					Algorithm: tpm.AlgAES,
+					KeyBits: tpmu.SymKeyBits{
+						AES: helpers.NewKeyBits(128),
 					},
-					CurveID: tpm.ECCNistP256,
+					Mode: tpmu.SymMode{
+						AES: helpers.NewAlgID(tpm.AlgCFB),
+					},
 				},
+				CurveID: tpm.ECCNistP256,
 			},
-			Unique: tpmu.PublicID{
-				ECC: &tpms.ECCPoint{
-					X: tpm2b.ECCParameter{
-						Buffer: make([]byte, 32),
-					},
-					Y: tpm2b.ECCParameter{
-						Buffer: make([]byte, 32),
-					},
+		},
+		Unique: tpmu.PublicID{
+			ECC: &tpms.ECCPoint{
+				X: tpm2b.ECCParameter{
+					Buffer: make([]byte, 32),
+				},
+				Y: tpm2b.ECCParameter{
+					Buffer: make([]byte, 32),
 				},
 			},
 		},
 	}
+
 	// ECCEKTemplate contains the TCG reference ECC-P256 EK template.
-	ECCEKTemplate = tpm2b.Public{
-		PublicArea: tpmt.Public{
-			Type:    tpm.AlgECC,
-			NameAlg: tpm.AlgSHA256,
-			ObjectAttributes: tpma.Object{
-				FixedTPM:             true,
-				STClear:              false,
-				FixedParent:          true,
-				SensitiveDataOrigin:  true,
-				UserWithAuth:         false,
-				AdminWithPolicy:      true,
-				NoDA:                 false,
-				EncryptedDuplication: false,
-				Restricted:           true,
-				Decrypt:              true,
-				SignEncrypt:          false,
+	ECCEKTemplate = tpmt.Public{
+		Type:    tpm.AlgECC,
+		NameAlg: tpm.AlgSHA256,
+		ObjectAttributes: tpma.Object{
+			FixedTPM:             true,
+			STClear:              false,
+			FixedParent:          true,
+			SensitiveDataOrigin:  true,
+			UserWithAuth:         false,
+			AdminWithPolicy:      true,
+			NoDA:                 false,
+			EncryptedDuplication: false,
+			Restricted:           true,
+			Decrypt:              true,
+			SignEncrypt:          false,
+		},
+		AuthPolicy: tpm2b.Digest{
+			Buffer: []byte{
+				// tpm.2_PolicySecret(RH_ENDORSEMENT)
+				0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xB3, 0xF8,
+				0x1A, 0x90, 0xCC, 0x8D, 0x46, 0xA5, 0xD7, 0x24,
+				0xFD, 0x52, 0xD7, 0x6E, 0x06, 0x52, 0x0B, 0x64,
+				0xF2, 0xA1, 0xDA, 0x1B, 0x33, 0x14, 0x69, 0xAA,
 			},
-			AuthPolicy: tpm2b.Digest{
-				Buffer: []byte{
-					// tpm.2_PolicySecret(RH_ENDORSEMENT)
-					0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xB3, 0xF8,
-					0x1A, 0x90, 0xCC, 0x8D, 0x46, 0xA5, 0xD7, 0x24,
-					0xFD, 0x52, 0xD7, 0x6E, 0x06, 0x52, 0x0B, 0x64,
-					0xF2, 0xA1, 0xDA, 0x1B, 0x33, 0x14, 0x69, 0xAA,
+		},
+		Parameters: tpmu.PublicParms{
+			ECCDetail: &tpms.ECCParms{
+				Symmetric: tpmt.SymDefObject{
+					Algorithm: tpm.AlgAES,
+					KeyBits: tpmu.SymKeyBits{
+						AES: helpers.NewKeyBits(128),
+					},
+					Mode: tpmu.SymMode{
+						AES: helpers.NewAlgID(tpm.AlgCFB),
+					},
 				},
+				CurveID: tpm.ECCNistP256,
 			},
-			Parameters: tpmu.PublicParms{
-				ECCDetail: &tpms.ECCParms{
-					Symmetric: tpmt.SymDefObject{
-						Algorithm: tpm.AlgAES,
-						KeyBits: tpmu.SymKeyBits{
-							AES: helpers.NewKeyBits(128),
-						},
-						Mode: tpmu.SymMode{
-							AES: helpers.NewAlgID(tpm.AlgCFB),
-						},
-					},
-					CurveID: tpm.ECCNistP256,
+		},
+		Unique: tpmu.PublicID{
+			ECC: &tpms.ECCPoint{
+				X: tpm2b.ECCParameter{
+					Buffer: make([]byte, 32),
 				},
-			},
-			Unique: tpmu.PublicID{
-				ECC: &tpms.ECCPoint{
-					X: tpm2b.ECCParameter{
-						Buffer: make([]byte, 32),
-					},
-					Y: tpm2b.ECCParameter{
-						Buffer: make([]byte, 32),
-					},
+				Y: tpm2b.ECCParameter{
+					Buffer: make([]byte, 32),
 				},
 			},
 		},

--- a/direct/tpm2/audit_test.go
+++ b/direct/tpm2/audit_test.go
@@ -69,8 +69,8 @@ func TestAuditSession(t *testing.T) {
 	}
 	defer func() {
 		// Flush the AK
-		flushCmd := FlushContext{FlushHandle: createAKRsp.ObjectHandle}
-		if _, err := flushCmd.Execute(thetpm); err != nil {
+		flush := FlushContext{FlushHandle: createAKRsp.ObjectHandle}
+		if err := flush.Execute(thetpm); err != nil {
 			t.Errorf("%v", err)
 		}
 	}()

--- a/direct/tpm2/create_loaded_test.go
+++ b/direct/tpm2/create_loaded_test.go
@@ -1,0 +1,171 @@
+package tpm2
+
+import (
+	"testing"
+
+	"github.com/google/go-tpm/direct/structures/tpm"
+	"github.com/google/go-tpm/direct/structures/tpm2b"
+	"github.com/google/go-tpm/direct/structures/tpma"
+	"github.com/google/go-tpm/direct/structures/tpms"
+	"github.com/google/go-tpm/direct/structures/tpmt"
+	"github.com/google/go-tpm/direct/structures/tpmu"
+	"github.com/google/go-tpm/direct/templates"
+	"github.com/google/go-tpm/direct/transport"
+	"github.com/google/go-tpm/direct/transport/simulator"
+)
+
+func getDeriver(t *testing.T, thetpm transport.TPM) NamedHandle {
+	t.Helper()
+
+	cl := CreateLoaded{
+		ParentHandle: tpm.RHOwner,
+		InPublic: tpm2b.Template{
+			Template: tpmt.Public{
+				Type:    tpm.AlgKeyedHash,
+				NameAlg: tpm.AlgSHA256,
+				ObjectAttributes: tpma.Object{
+					SensitiveDataOrigin: true,
+					UserWithAuth:        true,
+					Decrypt:             true,
+					Restricted:          true,
+				},
+				Parameters: tpmu.PublicParms{
+					KeyedHashDetail: &tpms.KeyedHashParms{
+						Scheme: tpmt.KeyedHashScheme{
+							Scheme: tpm.AlgXOR,
+							Details: tpmu.SchemeKeyedHash{
+								XOR: &tpms.SchemeXOR{
+									HashAlg: tpm.AlgSHA256,
+									KDF:     tpm.AlgKDF1SP800108,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	rsp, err := cl.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("could not create derivation parent: %v:", err)
+	}
+	return NamedHandle{
+		Handle: rsp.ObjectHandle,
+		Name:   rsp.Name,
+	}
+}
+
+func TestCreateLoaded(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	deriver := getDeriver(t, thetpm)
+
+	createLoadeds := map[string]*CreateLoaded{
+		"PrimaryKey": {
+			ParentHandle: tpm.RHEndorsement,
+			InPublic: tpm2b.Template{
+				Template: templates.ECCEKTemplate,
+			},
+		},
+		"OrdinaryKey": {
+			ParentHandle: tpm.RHOwner,
+			InSensitive: tpm2b.SensitiveCreate{
+				Sensitive: tpms.SensitiveCreate{
+					UserAuth: tpm2b.Auth{
+						Buffer: []byte("p@ssw0rd"),
+					},
+				},
+			},
+			InPublic: tpm2b.Template{
+				Template: tpmt.Public{
+					Type:    tpm.AlgECC,
+					NameAlg: tpm.AlgSHA256,
+					ObjectAttributes: tpma.Object{
+						SensitiveDataOrigin: true,
+						UserWithAuth:        true,
+						SignEncrypt:         true,
+					},
+					Parameters: tpmu.PublicParms{
+						ECCDetail: &tpms.ECCParms{
+							CurveID: tpm.ECCNistP256,
+						},
+					},
+				},
+			},
+		},
+		"DataBlob": {
+			ParentHandle: tpm.RHOwner,
+			InSensitive: tpm2b.SensitiveCreate{
+				Sensitive: tpms.SensitiveCreate{
+					UserAuth: tpm2b.Auth{
+						Buffer: []byte("p@ssw0rd"),
+					},
+					Data: tpm2b.SensitiveData{
+						Buffer: []byte("secrets"),
+					},
+				},
+			},
+			InPublic: tpm2b.Template{
+				Template: tpmt.Public{
+					Type:    tpm.AlgKeyedHash,
+					NameAlg: tpm.AlgSHA256,
+					ObjectAttributes: tpma.Object{
+						UserWithAuth: true,
+					},
+				},
+			},
+		},
+		"Derived": {
+			ParentHandle: deriver,
+			InSensitive: tpm2b.SensitiveCreate{
+				Sensitive: tpms.SensitiveCreate{
+					UserAuth: tpm2b.Auth{
+						Buffer: []byte("p@ssw0rd"),
+					},
+					Data: tpm2b.Derive{
+						Buffer: tpms.Derive{
+							Label: tpm2b.Label{
+								Buffer: []byte("label"),
+							},
+							Context: tpm2b.Label{
+								Buffer: []byte("context"),
+							},
+						},
+					},
+				},
+			},
+			InPublic: tpm2b.Template{
+				Template: tpmt.Public{
+					Type:    tpm.AlgECC,
+					NameAlg: tpm.AlgSHA256,
+					ObjectAttributes: tpma.Object{
+						FixedParent:  true,
+						UserWithAuth: true,
+						SignEncrypt:  true,
+					},
+					Parameters: tpmu.PublicParms{
+						ECCDetail: &tpms.ECCParms{
+							CurveID: tpm.ECCNistP256,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, createLoaded := range createLoadeds {
+		t.Run(name, func(t *testing.T) {
+			rsp, err := createLoaded.Execute(thetpm)
+			if err != nil {
+				t.Fatalf("error from CreateLoaded: %v", err)
+			}
+			if err = (&FlushContext{FlushHandle: rsp.ObjectHandle}).Execute(thetpm); err != nil {
+				t.Errorf("error from FlushContext: %v", err)
+			}
+		})
+	}
+}

--- a/direct/tpm2/ek_test.go
+++ b/direct/tpm2/ek_test.go
@@ -120,8 +120,8 @@ func ekTest(t *testing.T, ekTemplate tpm2b.Public) {
 			}
 			defer func() {
 				// Flush the EK
-				flushEKCmd := FlushContext{createEKRsp.ObjectHandle}
-				if _, err := flushEKCmd.Execute(thetpm); err != nil {
+				flush := FlushContext{createEKRsp.ObjectHandle}
+				if err := flush.Execute(thetpm); err != nil {
 					t.Errorf("%v", err)
 				}
 			}()

--- a/direct/tpm2/ek_test.go
+++ b/direct/tpm2/ek_test.go
@@ -17,7 +17,7 @@ import (
 
 // Test creating a sealed data blob on the standard-template EK using its policy.
 func TestEKPolicy(t *testing.T) {
-	templates := map[string]tpm2b.Public{
+	templates := map[string]tpmt.Public{
 		"RSA": templates.RSAEKTemplate,
 		"ECC": templates.ECCEKTemplate,
 	}
@@ -41,7 +41,7 @@ func ekPolicy(t transport.TPM, handle tpmi.SHPolicy, nonceTPM tpm2b.Nonce) error
 }
 
 // This function tests a lot of combinations of authorizing the EK policy.
-func ekTest(t *testing.T, ekTemplate tpm2b.Public) {
+func ekTest(t *testing.T, ekTemplate tpmt.Public) {
 	type ekTestCase struct {
 		name string
 		// Use Policy instead of PolicySession, passing the callback instead of
@@ -108,7 +108,9 @@ func ekTest(t *testing.T, ekTemplate tpm2b.Public) {
 			// Create the EK
 			createEKCmd := CreatePrimary{
 				PrimaryHandle: tpm.RHEndorsement,
-				InPublic:      ekTemplate,
+				InPublic: tpm2b.Public{
+					PublicArea: ekTemplate,
+				},
 			}
 			createEKRsp, err := createEKCmd.Execute(thetpm)
 			if err != nil {
@@ -136,7 +138,7 @@ func ekTest(t *testing.T, ekTemplate tpm2b.Public) {
 				},
 				InSensitive: tpm2b.SensitiveCreate{
 					Sensitive: tpms.SensitiveCreate{
-						Data: tpm2b.Data{
+						Data: tpm2b.SensitiveData{
 							Buffer: data,
 						},
 					},

--- a/direct/tpm2/load_external_test.go
+++ b/direct/tpm2/load_external_test.go
@@ -1,0 +1,96 @@
+package tpm2
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/google/go-tpm/direct/structures/tpm"
+	"github.com/google/go-tpm/direct/structures/tpm2b"
+	"github.com/google/go-tpm/direct/structures/tpma"
+	"github.com/google/go-tpm/direct/structures/tpms"
+	"github.com/google/go-tpm/direct/structures/tpmt"
+	"github.com/google/go-tpm/direct/structures/tpmu"
+	"github.com/google/go-tpm/direct/transport/simulator"
+)
+
+func decodeHex(t *testing.T, h string) []byte {
+	t.Helper()
+	data, err := hex.DecodeString(h)
+	if err != nil {
+		t.Fatalf("could not decode '%v' as hex data: %v", h, err)
+	}
+	return data
+}
+
+func TestLoadExternal(t *testing.T) {
+	loads := map[string]*LoadExternal{
+		"ECCNoSensitive": {
+			InPublic: tpm2b.Public{
+				PublicArea: tpmt.Public{
+					Type:    tpm.AlgECC,
+					NameAlg: tpm.AlgSHA256,
+					ObjectAttributes: tpma.Object{
+						SignEncrypt: true,
+					},
+					Parameters: tpmu.PublicParms{
+						ECCDetail: &tpms.ECCParms{
+							CurveID: tpm.ECCNistP256,
+						},
+					},
+					Unique: tpmu.PublicID{
+						// This happens to be a P256 EKpub from the simulator
+						ECC: &tpms.ECCPoint{
+							X: tpm2b.ECCParameter{Buffer: decodeHex(t, "9855efa3514873b88067ab127b2d4692864a395db3d9e4ccad0592478a245c16")},
+							Y: tpm2b.ECCParameter{Buffer: decodeHex(t, "e802a26649839a2d7b13c812a5dc0b61c110cbe62db784d96e60a823448c8993")},
+						},
+					},
+				},
+			},
+		},
+		"KeyedHashSensitive": {
+			InPrivate: &tpm2b.Sensitive{
+				SensitiveArea: tpmt.Sensitive{
+					SensitiveType: tpm.AlgKeyedHash,
+					SeedValue: tpm2b.Digest{
+						Buffer: []byte("obfuscation is my middle name!!!"),
+					},
+					Sensitive: tpmu.SensitiveComposite{
+						Bits: &tpm2b.SensitiveData{
+							Buffer: []byte("secrets"),
+						},
+					},
+				},
+			},
+			InPublic: tpm2b.Public{
+				PublicArea: tpmt.Public{
+					Type:    tpm.AlgKeyedHash,
+					NameAlg: tpm.AlgSHA256,
+					Unique: tpmu.PublicID{
+						KeyedHash: &tpm2b.Digest{
+							// SHA256("obfuscation is my middle name!!!secrets")
+							Buffer: decodeHex(t, "ed4fe8e2bff97665e7bfbe27c2365d07a9be91dd92d997cd91cc706b6074eb08"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	for name, load := range loads {
+		t.Run(name, func(t *testing.T) {
+			rsp, err := load.Execute(thetpm)
+			if err != nil {
+				t.Fatalf("error from LoadExternal: %v", err)
+			}
+			if err = (&FlushContext{FlushHandle: rsp.ObjectHandle}).Execute(thetpm); err != nil {
+				t.Errorf("error from FlushContext: %v", err)
+			}
+		})
+	}
+}

--- a/direct/tpm2/names.go
+++ b/direct/tpm2/names.go
@@ -1,0 +1,58 @@
+package tpm2
+
+import (
+	"encoding/binary"
+
+	"github.com/google/go-tpm/direct/structures/tpm"
+	"github.com/google/go-tpm/direct/structures/tpm2b"
+	"github.com/google/go-tpm/direct/structures/tpms"
+	"github.com/google/go-tpm/direct/structures/tpmt"
+)
+
+// HandleName returns the TPM Name of a PCR, session, or permanent value
+// (e.g., hierarchy) handle.
+func HandleName(h tpm.Handle) tpm2b.Name {
+	result := make([]byte, 4)
+	binary.BigEndian.PutUint32(result, uint32(h))
+	return tpm2b.Name{
+		Buffer: result,
+	}
+}
+
+// objectOrNVName calculates the Name of an NV index or object.
+// pub is a pointer to either a tpmt.Public or tpms.NVPublic.
+func objectOrNVName(alg tpm.AlgID, pub interface{}) (*tpm2b.Name, error) {
+	h, err := alg.Hash()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a byte slice with the correct reserved size and marshal the
+	// NameAlg to it.
+	result := make([]byte, 2, 2+h.Size())
+	binary.BigEndian.PutUint16(result, uint16(alg))
+
+	// Calculate the hash of the entire Public contents and append it to the
+	// result.
+	ha := h.New()
+	marshalledPub, err := Marshal(pub)
+	if err != nil {
+		return nil, err
+	}
+	ha.Write(marshalledPub)
+	result = ha.Sum(result)
+
+	return &tpm2b.Name{
+		Buffer: result,
+	}, nil
+}
+
+// ObjectName returns the TPM Name of an object.
+func ObjectName(p *tpmt.Public) (*tpm2b.Name, error) {
+	return objectOrNVName(p.NameAlg, p)
+}
+
+// NVName returns the TPM Name of an NV index.
+func NVName(p *tpms.NVPublic) (*tpm2b.Name, error) {
+	return objectOrNVName(p.NameAlg, p)
+}

--- a/direct/tpm2/names_test.go
+++ b/direct/tpm2/names_test.go
@@ -29,7 +29,9 @@ func TestObjectName(t *testing.T) {
 
 	createPrimary := CreatePrimary{
 		PrimaryHandle: tpm.RHEndorsement,
-		InPublic:      templates.ECCEKTemplate,
+		InPublic: tpm2b.Public{
+			PublicArea: templates.ECCEKTemplate,
+		},
 	}
 	rsp, err := createPrimary.Execute(thetpm)
 	if err != nil {

--- a/direct/tpm2/names_test.go
+++ b/direct/tpm2/names_test.go
@@ -1,0 +1,96 @@
+package tpm2
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-tpm/direct/structures/tpm"
+	"github.com/google/go-tpm/direct/structures/tpm2b"
+	"github.com/google/go-tpm/direct/structures/tpma"
+	"github.com/google/go-tpm/direct/structures/tpms"
+	"github.com/google/go-tpm/direct/templates"
+	"github.com/google/go-tpm/direct/transport/simulator"
+)
+
+func TestHandleName(t *testing.T) {
+	want := []byte{0x40, 0x00, 0x00, 0x0B}
+	name := HandleName(tpm.RHEndorsement)
+	if !bytes.Equal(want, name.Buffer) {
+		t.Errorf("Incorrect name for RH_ENDORSEMENT (want %x got %x)", want, name.Buffer)
+	}
+}
+
+func TestObjectName(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	createPrimary := CreatePrimary{
+		PrimaryHandle: tpm.RHEndorsement,
+		InPublic:      templates.ECCEKTemplate,
+	}
+	rsp, err := createPrimary.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("could not call TPM2_CreatePrimary: %v", err)
+	}
+	flush := FlushContext{FlushHandle: rsp.ObjectHandle}
+	defer flush.Execute(thetpm)
+	public := rsp.OutPublic
+
+	want := rsp.Name
+	name, err := ObjectName(&public.PublicArea)
+	if err != nil {
+		t.Fatalf("error from ObjectName: %v", err)
+	}
+	if !bytes.Equal(want.Buffer, name.Buffer) {
+		t.Errorf("Incorrect name for ECC EK (want %x got %x)", want.Buffer, name.Buffer)
+	}
+}
+
+func TestNVName(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	public := tpm2b.NVPublic{
+		NVPublic: tpms.NVPublic{
+			NVIndex: tpm.Handle(0x0180000F),
+			NameAlg: tpm.AlgSHA256,
+			Attributes: tpma.NV{
+				OwnerWrite: true,
+				OwnerRead:  true,
+				NT:         tpm.NTOrdinary,
+			},
+			DataSize: 4,
+		},
+	}
+
+	defineSpace := NVDefineSpace{
+		AuthHandle: tpm.RHOwner,
+		PublicInfo: public,
+	}
+	if err := defineSpace.Execute(thetpm); err != nil {
+		t.Fatalf("could not call TPM2_DefineSpace: %v", err)
+	}
+
+	readPublic := NVReadPublic{
+		NVIndex: public.NVPublic.NVIndex,
+	}
+	rsp, err := readPublic.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("could not call TPM2_ReadPublic: %v", err)
+	}
+
+	want := rsp.NVName
+	name, err := NVName(&public.NVPublic)
+	if err != nil {
+		t.Fatalf("error from NVIndexName: %v", err)
+	}
+	if !bytes.Equal(want.Buffer, name.Buffer) {
+		t.Errorf("Incorrect name for NV index (want %x got %x)", want.Buffer, name.Buffer)
+	}
+}

--- a/direct/tpm2/nv_test.go
+++ b/direct/tpm2/nv_test.go
@@ -1,0 +1,95 @@
+package tpm2
+
+import (
+	"testing"
+
+	"github.com/google/go-tpm/direct/structures/tpm"
+	"github.com/google/go-tpm/direct/structures/tpm2b"
+	"github.com/google/go-tpm/direct/structures/tpma"
+	"github.com/google/go-tpm/direct/structures/tpms"
+	"github.com/google/go-tpm/direct/transport/simulator"
+)
+
+func TestNVAuthWrite(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	def := NVDefineSpace{
+		AuthHandle: tpm.RHOwner,
+		Auth: tpm2b.Auth{
+			Buffer: []byte("p@ssw0rd"),
+		},
+		PublicInfo: tpm2b.NVPublic{
+			NVPublic: tpms.NVPublic{
+				NVIndex: tpm.Handle(0x0180000F),
+				NameAlg: tpm.AlgSHA256,
+				Attributes: tpma.NV{
+					OwnerWrite: true,
+					OwnerRead:  true,
+					AuthWrite:  true,
+					AuthRead:   true,
+					NT:         tpm.NTOrdinary,
+					NoDA:       true,
+				},
+				DataSize: 4,
+			},
+		},
+	}
+	if err := def.Execute(thetpm); err != nil {
+		t.Fatalf("Calling TPM2_NV_DefineSpace: %v", err)
+	}
+
+	nvName, err := NVName(&def.PublicInfo.NVPublic)
+	if err != nil {
+		t.Fatalf("Calculating name of NV index: %v", err)
+	}
+
+	prewrite := NVWrite{
+		AuthHandle: AuthHandle{
+			Handle: def.PublicInfo.NVPublic.NVIndex,
+			Name:   *nvName,
+			Auth:   PasswordAuth([]byte("p@ssw0rd")),
+		},
+		NVIndex: NamedHandle{
+			Handle: def.PublicInfo.NVPublic.NVIndex,
+			Name:   *nvName,
+		},
+		Data: tpm2b.MaxNVBuffer{
+			Buffer: []byte{0x01, 0x02, 0x03, 0x04},
+		},
+		Offset: 0,
+	}
+	if err := prewrite.Execute(thetpm); err != nil {
+		t.Errorf("Calling TPM2_NV_Write: %v", err)
+	}
+
+	read := NVReadPublic{
+		NVIndex: def.PublicInfo.NVPublic.NVIndex,
+	}
+	readRsp, err := read.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("Calling TPM2_NV_ReadPublic: %v", err)
+	}
+	t.Logf("Name: %x", readRsp.NVName.Buffer)
+
+	write := NVWrite{
+		AuthHandle: AuthHandle{
+			Handle: tpm.RHOwner,
+			Auth:   HMAC(tpm.AlgSHA256, 16, Auth([]byte{})),
+		},
+		NVIndex: NamedHandle{
+			Handle: def.PublicInfo.NVPublic.NVIndex,
+			Name:   readRsp.NVName,
+		},
+		Data: tpm2b.MaxNVBuffer{
+			Buffer: []byte{0x01, 0x02, 0x03, 0x04},
+		},
+		Offset: 0,
+	}
+	if err := write.Execute(thetpm); err != nil {
+		t.Errorf("Calling TPM2_NV_Write: %v", err)
+	}
+}

--- a/direct/tpm2/policy.go
+++ b/direct/tpm2/policy.go
@@ -1,0 +1,59 @@
+package tpm2
+
+import (
+	"crypto"
+
+	"github.com/google/go-tpm/direct/structures/tpmi"
+	"github.com/google/go-tpm/direct/structures/tpmt"
+)
+
+// PolicyCalculator represents a TPM 2.0 policy that needs to be calculated
+// synthetically (i.e., without a TPM).
+type PolicyCalculator struct {
+	alg   tpmi.AlgHash
+	hash  crypto.Hash
+	state []byte
+}
+
+// NewPolicyCalculator creates a fresh policy using the given hash algorithm.
+func NewPolicyCalculator(alg tpmi.AlgHash) (*PolicyCalculator, error) {
+	hash, err := alg.Hash()
+	if err != nil {
+		return nil, err
+	}
+	return &PolicyCalculator{
+		alg:   alg,
+		hash:  hash,
+		state: make([]byte, hash.Size()),
+	}, nil
+}
+
+// Reset resets the internal state of the policy hash to all 0x00.
+func (p *PolicyCalculator) Reset() {
+	p.state = make([]byte, p.hash.Size())
+}
+
+// Update updates the internal state of the policy hash by appending the
+// current state with the given contents, and updating the new state to the
+// hash of that.
+func (p *PolicyCalculator) Update(data ...interface{}) error {
+	hash := p.hash.New()
+	hash.Write(p.state)
+	serialized, err := Marshal(data...)
+	if err != nil {
+		return err
+	}
+	hash.Write(serialized)
+	p.state = hash.Sum(nil)
+	return nil
+}
+
+// Hash returns the current state of the policy hash.
+func (p *PolicyCalculator) Hash() *tpmt.HA {
+	result := tpmt.HA{
+		HashAlg: p.alg,
+		Digest:  make([]byte, len(p.state)),
+	}
+	copy(result.Digest, p.state)
+	return &result
+}

--- a/direct/tpm2/policy_test.go
+++ b/direct/tpm2/policy_test.go
@@ -1,0 +1,540 @@
+package tpm2
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-tpm/direct/structures/tpm"
+	"github.com/google/go-tpm/direct/structures/tpm2b"
+	"github.com/google/go-tpm/direct/structures/tpma"
+	"github.com/google/go-tpm/direct/structures/tpml"
+	"github.com/google/go-tpm/direct/structures/tpms"
+	"github.com/google/go-tpm/direct/structures/tpmt"
+	"github.com/google/go-tpm/direct/structures/tpmu"
+	"github.com/google/go-tpm/direct/transport"
+	"github.com/google/go-tpm/direct/transport/simulator"
+)
+
+func signingKey(t *testing.T, thetpm transport.TPM) (NamedHandle, func()) {
+	t.Helper()
+	createPrimary := CreatePrimary{
+		PrimaryHandle: tpm.RHOwner,
+		InPublic: tpm2b.Public{
+			PublicArea: tpmt.Public{
+				Type:    tpm.AlgECC,
+				NameAlg: tpm.AlgSHA256,
+				ObjectAttributes: tpma.Object{
+					FixedTPM:            true,
+					FixedParent:         true,
+					SensitiveDataOrigin: true,
+					UserWithAuth:        true,
+					SignEncrypt:         true,
+				},
+				Parameters: tpmu.PublicParms{
+					ECCDetail: &tpms.ECCParms{
+						Scheme: tpmt.ECCScheme{
+							Scheme: tpm.AlgECDSA,
+							Details: tpmu.AsymScheme{
+								ECDSA: &tpms.SigSchemeECDSA{
+									HashAlg: tpm.AlgSHA256,
+								},
+							},
+						},
+						CurveID: tpm.ECCNistP256,
+					},
+				},
+			},
+		},
+	}
+	rsp, err := createPrimary.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("could not create key: %v", err)
+	}
+	cleanup := func() {
+		t.Helper()
+		flush := FlushContext{
+			FlushHandle: rsp.ObjectHandle,
+		}
+		if err := flush.Execute(thetpm); err != nil {
+			t.Errorf("could not flush signing key: %v", err)
+		}
+	}
+	return NamedHandle{
+		Handle: rsp.ObjectHandle,
+		Name:   rsp.Name,
+	}, cleanup
+}
+
+func nvIndex(t *testing.T, thetpm transport.TPM) (NamedHandle, func()) {
+	t.Helper()
+	defSpace := NVDefineSpace{
+		AuthHandle: tpm.RHOwner,
+		PublicInfo: tpm2b.NVPublic{
+			NVPublic: tpms.NVPublic{
+				NVIndex: 0x01800001,
+				NameAlg: tpm.AlgSHA256,
+				Attributes: tpma.NV{
+					OwnerWrite: true,
+					AuthRead:   true,
+					NT:         tpm.NTOrdinary,
+				},
+			},
+		},
+	}
+	if err := defSpace.Execute(thetpm); err != nil {
+		t.Fatalf("could not create NV index: %v", err)
+	}
+	readPub := NVReadPublic{
+		NVIndex: defSpace.PublicInfo.NVPublic.NVIndex,
+	}
+	readRsp, err := readPub.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("could not read NV index public info: %v", err)
+	}
+	cleanup := func() {
+		t.Helper()
+		undefine := NVUndefineSpace{
+			AuthHandle: tpm.RHOwner,
+			NVIndex: NamedHandle{
+				defSpace.PublicInfo.NVPublic.NVIndex,
+				readRsp.NVName,
+			},
+		}
+		if err := undefine.Execute(thetpm); err != nil {
+			t.Errorf("could not undefine NV index: %v", err)
+		}
+	}
+	return NamedHandle{
+		Handle: defSpace.PublicInfo.NVPublic.NVIndex,
+		Name:   readRsp.NVName,
+	}, cleanup
+}
+
+func TestPolicySignedUpdate(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	sk, cleanup := signingKey(t, thetpm)
+	defer cleanup()
+
+	// Use a trial session to calculate this policy
+	sess, cleanup2, err := PolicySession(thetpm, tpm.AlgSHA256, 16, Trial())
+	if err != nil {
+		t.Fatalf("setting up policy session: %v", err)
+	}
+	defer func() {
+		t.Helper()
+		if err := cleanup2(); err != nil {
+			t.Errorf("cleaning up policy session: %v", err)
+		}
+	}()
+
+	policySigned := PolicySigned{
+		AuthObject:    sk,
+		PolicySession: sess.Handle(),
+		PolicyRef:     tpm2b.Nonce{Buffer: []byte{5, 6, 7, 8}},
+		Auth: tpmt.Signature{
+			SigAlg: tpm.AlgECDSA,
+			Signature: tpmu.Signature{
+				ECDSA: &tpms.SignatureECC{
+					Hash: tpm.AlgSHA256,
+				},
+			},
+		},
+	}
+
+	if _, err := policySigned.Execute(thetpm); err != nil {
+		t.Fatalf("executing PolicySigned: %v", err)
+	}
+
+	pgd := PolicyGetDigest{
+		PolicySession: sess.Handle(),
+	}
+	want, err := pgd.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("executing PolicyGetDigest: %v", err)
+	}
+
+	// Use the policy helper to calculate the same policy
+	pol, err := NewPolicyCalculator(tpm.AlgSHA256)
+	if err != nil {
+		t.Fatalf("creating policy calculator: %v", err)
+	}
+	policySigned.Update(pol)
+	got := pol.Hash()
+
+	if !bytes.Equal(got.Digest, want.PolicyDigest.Buffer) {
+		t.Errorf("policySigned.Hash() = %x,\nwant %x", got.Digest, want.PolicyDigest.Buffer)
+	}
+}
+
+func TestPolicySecretUpdate(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	sk, cleanup := signingKey(t, thetpm)
+	defer cleanup()
+
+	// Use a trial session to calculate this policy
+	sess, cleanup2, err := PolicySession(thetpm, tpm.AlgSHA256, 16, Trial())
+	if err != nil {
+		t.Fatalf("setting up policy session: %v", err)
+	}
+	defer func() {
+		t.Helper()
+		if err := cleanup2(); err != nil {
+			t.Errorf("cleaning up policy session: %v", err)
+		}
+	}()
+
+	policySecret := PolicySecret{
+		AuthHandle: NamedHandle{
+			Handle: sk.Handle,
+			Name:   sk.Name,
+		},
+		PolicySession: sess.Handle(),
+		PolicyRef:     tpm2b.Nonce{Buffer: []byte{5, 6, 7, 8}},
+	}
+
+	if _, err := policySecret.Execute(thetpm); err != nil {
+		t.Fatalf("executing PolicySecret: %v", err)
+	}
+
+	pgd := PolicyGetDigest{
+		PolicySession: sess.Handle(),
+	}
+	want, err := pgd.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("executing PolicyGetDigest: %v", err)
+	}
+
+	// Use the policy helper to calculate the same policy
+	pol, err := NewPolicyCalculator(tpm.AlgSHA256)
+	if err != nil {
+		t.Fatalf("creating policy calculator: %v", err)
+	}
+	policySecret.Update(pol)
+	got := pol.Hash()
+
+	if !bytes.Equal(got.Digest, want.PolicyDigest.Buffer) {
+		t.Errorf("policySecret.Hash() = %x,\nwant %x", got.Digest, want.PolicyDigest.Buffer)
+	}
+}
+
+func TestPolicyOrUpdate(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	// Use a trial session to calculate this policy
+	sess, cleanup2, err := PolicySession(thetpm, tpm.AlgSHA256, 16, Trial())
+	if err != nil {
+		t.Fatalf("setting up policy session: %v", err)
+	}
+	defer func() {
+		t.Helper()
+		if err := cleanup2(); err != nil {
+			t.Errorf("cleaning up policy session: %v", err)
+		}
+	}()
+
+	policyOr := PolicyOr{
+		PolicySession: sess.Handle(),
+		PHashList: tpml.Digest{
+			Digests: []tpm2b.Digest{
+				{Buffer: []byte{1, 2, 3}},
+				{Buffer: []byte{4, 5, 6}},
+			},
+		},
+	}
+
+	if err := policyOr.Execute(thetpm); err != nil {
+		t.Fatalf("executing PolicyOr: %v", err)
+	}
+
+	pgd := PolicyGetDigest{
+		PolicySession: sess.Handle(),
+	}
+	want, err := pgd.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("executing PolicyGetDigest: %v", err)
+	}
+
+	// Use the policy helper to calculate the same policy
+	pol, err := NewPolicyCalculator(tpm.AlgSHA256)
+	if err != nil {
+		t.Fatalf("creating policy calculator: %v", err)
+	}
+	policyOr.Update(pol)
+	got := pol.Hash()
+
+	if !bytes.Equal(got.Digest, want.PolicyDigest.Buffer) {
+		t.Errorf("policyOr.Hash() = %x,\nwant %x", got.Digest, want.PolicyDigest.Buffer)
+	}
+}
+
+func TestPolicyCpHashUpdate(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	// Use a trial session to calculate this policy
+	sess, cleanup2, err := PolicySession(thetpm, tpm.AlgSHA256, 16, Trial())
+	if err != nil {
+		t.Fatalf("setting up policy session: %v", err)
+	}
+	defer func() {
+		t.Helper()
+		if err := cleanup2(); err != nil {
+			t.Errorf("cleaning up policy session: %v", err)
+		}
+	}()
+
+	policyCpHash := PolicyCPHash{
+		PolicySession: sess.Handle(),
+		CPHashA: tpm2b.Digest{Buffer: []byte{
+			1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+			1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
+	}
+
+	if err := policyCpHash.Execute(thetpm); err != nil {
+		t.Fatalf("executing PolicyCpHash: %v", err)
+	}
+
+	pgd := PolicyGetDigest{
+		PolicySession: sess.Handle(),
+	}
+	want, err := pgd.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("executing PolicyGetDigest: %v", err)
+	}
+
+	// Use the policy helper to calculate the same policy
+	pol, err := NewPolicyCalculator(tpm.AlgSHA256)
+	if err != nil {
+		t.Fatalf("creating policy calculator: %v", err)
+	}
+	policyCpHash.Update(pol)
+	got := pol.Hash()
+
+	if !bytes.Equal(got.Digest, want.PolicyDigest.Buffer) {
+		t.Errorf("policyCpHash.Hash() = %x,\nwant %x", got.Digest, want.PolicyDigest.Buffer)
+	}
+}
+
+func TestPolicyAuthorizeUpdate(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	// Use a trial session to calculate this policy
+	sess, cleanup2, err := PolicySession(thetpm, tpm.AlgSHA256, 16, Trial())
+	if err != nil {
+		t.Fatalf("setting up policy session: %v", err)
+	}
+	defer func() {
+		t.Helper()
+		if err := cleanup2(); err != nil {
+			t.Errorf("cleaning up policy session: %v", err)
+		}
+	}()
+
+	sk, cleanup := signingKey(t, thetpm)
+	defer cleanup()
+
+	policyAuthorize := PolicyAuthorize{
+		PolicySession: sess.Handle(),
+		PolicyRef:     tpm2b.Digest{Buffer: []byte{5, 6, 7, 8}},
+		KeySign:       sk.Name,
+		CheckTicket: tpmt.TKVerified{
+			Tag:       tpm.STVerified,
+			Hierarchy: tpm.RHEndorsement,
+		},
+	}
+
+	if err := policyAuthorize.Execute(thetpm); err != nil {
+		t.Fatalf("executing PolicyAuthorize: %v", err)
+	}
+
+	pgd := PolicyGetDigest{
+		PolicySession: sess.Handle(),
+	}
+	want, err := pgd.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("executing PolicyGetDigest: %v", err)
+	}
+
+	// Use the policy helper to calculate the same policy
+	pol, err := NewPolicyCalculator(tpm.AlgSHA256)
+	if err != nil {
+		t.Fatalf("creating policy calculator: %v", err)
+	}
+	policyAuthorize.Update(pol)
+	got := pol.Hash()
+
+	if !bytes.Equal(got.Digest, want.PolicyDigest.Buffer) {
+		t.Errorf("policyAuthorize.Hash() = %x,\nwant %x", got.Digest, want.PolicyDigest.Buffer)
+	}
+}
+
+func TestPolicyNVWrittenUpdate(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	// Use a trial session to calculate this policy
+	sess, cleanup2, err := PolicySession(thetpm, tpm.AlgSHA256, 16, Trial())
+	if err != nil {
+		t.Fatalf("setting up policy session: %v", err)
+	}
+	defer func() {
+		t.Helper()
+		if err := cleanup2(); err != nil {
+			t.Errorf("cleaning up policy session: %v", err)
+		}
+	}()
+
+	policyNVWritten := PolicyNVWritten{
+		PolicySession: sess.Handle(),
+		WrittenSet:    true,
+	}
+
+	if _, err := policyNVWritten.Execute(thetpm); err != nil {
+		t.Fatalf("executing PolicyNVWritten: %v", err)
+	}
+
+	pgd := PolicyGetDigest{
+		PolicySession: sess.Handle(),
+	}
+	want, err := pgd.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("executing PolicyGetDigest: %v", err)
+	}
+
+	// Use the policy helper to calculate the same policy
+	pol, err := NewPolicyCalculator(tpm.AlgSHA256)
+	if err != nil {
+		t.Fatalf("creating policy calculator: %v", err)
+	}
+	policyNVWritten.Update(pol)
+	got := pol.Hash()
+
+	if !bytes.Equal(got.Digest, want.PolicyDigest.Buffer) {
+		t.Errorf("PolicyNVWritten.Hash() = %x,\nwant %x", got.Digest, want.PolicyDigest.Buffer)
+	}
+}
+
+func TestPolicyAuthorizeNVUpdate(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	nv, cleanup := nvIndex(t, thetpm)
+	defer cleanup()
+
+	// Use a trial session to calculate this policy
+	sess, cleanup2, err := PolicySession(thetpm, tpm.AlgSHA256, 16, Trial())
+	if err != nil {
+		t.Fatalf("setting up policy session: %v", err)
+	}
+	defer func() {
+		t.Helper()
+		if err := cleanup2(); err != nil {
+			t.Errorf("cleaning up policy session: %v", err)
+		}
+	}()
+
+	policyAuthorizeNV := PolicyAuthorizeNV{
+		AuthHandle:    NamedHandle{Handle: nv.Handle, Name: nv.Name},
+		PolicySession: sess.Handle(),
+		NVIndex:       nv,
+	}
+
+	if err := policyAuthorizeNV.Execute(thetpm); err != nil {
+		t.Fatalf("executing PolicyAuthorizeNV: %v", err)
+	}
+
+	pgd := PolicyGetDigest{
+		PolicySession: sess.Handle(),
+	}
+	want, err := pgd.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("executing PolicyGetDigest: %v", err)
+	}
+
+	// Use the policy helper to calculate the same policy
+	pol, err := NewPolicyCalculator(tpm.AlgSHA256)
+	if err != nil {
+		t.Fatalf("creating policy calculator: %v", err)
+	}
+	policyAuthorizeNV.Update(pol)
+	got := pol.Hash()
+
+	if !bytes.Equal(got.Digest, want.PolicyDigest.Buffer) {
+		t.Errorf("PolicyAuthorizeNV.Hash() = %x,\nwant %x", got.Digest, want.PolicyDigest.Buffer)
+	}
+}
+
+func TestPolicyCommandCodeUpdate(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	// Use a trial session to calculate this policy
+	sess, cleanup2, err := PolicySession(thetpm, tpm.AlgSHA256, 16, Trial())
+	if err != nil {
+		t.Fatalf("setting up policy session: %v", err)
+	}
+	defer func() {
+		t.Helper()
+		if err := cleanup2(); err != nil {
+			t.Errorf("cleaning up policy session: %v", err)
+		}
+	}()
+
+	pcc := PolicyCommandCode{
+		PolicySession: sess.Handle(),
+		Code:          tpm.CCCreate,
+	}
+	if err := pcc.Execute(thetpm); err != nil {
+		t.Fatalf("executing PolicyCommandCode: %v", err)
+	}
+
+	pgd := PolicyGetDigest{
+		PolicySession: sess.Handle(),
+	}
+	want, err := pgd.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("executing PolicyGetDigest: %v", err)
+	}
+
+	// Use the policy helper to calculate the same policy
+	pol, err := NewPolicyCalculator(tpm.AlgSHA256)
+	if err != nil {
+		t.Fatalf("creating policy calculator: %v", err)
+	}
+	pcc.Update(pol)
+	got := pol.Hash()
+
+	if !bytes.Equal(got.Digest, want.PolicyDigest.Buffer) {
+		t.Errorf("PolicyCommandCode.Hash() = %x,\nwant %x", got.Digest, want.PolicyDigest.Buffer)
+	}
+}

--- a/direct/tpm2/reflect.go
+++ b/direct/tpm2/reflect.go
@@ -737,7 +737,7 @@ func taggedMembers(v reflect.Value, tag string, invert bool) []reflect.Value {
 func cmdAuths(cmd Command) ([]Session, error) {
 	authHandles := taggedMembers(reflect.ValueOf(cmd).Elem(), "auth", false)
 	var result []Session
-	for _, authHandle := range authHandles {
+	for i, authHandle := range authHandles {
 		// Dynamically check if the caller provided auth in an AuthHandle.
 		// If not, use an empty password auth.
 		// A cleaner way to do this would be to have an interface method that
@@ -745,6 +745,10 @@ func cmdAuths(cmd Command) ([]Session, error) {
 		// the internal package, so that tpm.Handle can return it.
 		// So instead, we live with a little more magic reflection behavior.
 		if h, ok := authHandle.Interface().(AuthHandle); ok {
+			if h.Auth == nil {
+				return nil, fmt.Errorf("missing auth for '%v' parameter",
+					reflect.ValueOf(cmd).Elem().Type().Field(i).Name)
+			}
 			result = append(result, h.Auth)
 		} else {
 			result = append(result, PasswordAuth(nil))

--- a/direct/tpm2/sealing_test.go
+++ b/direct/tpm2/sealing_test.go
@@ -58,7 +58,7 @@ func unsealingTest(t *testing.T, srkTemplate tpm2b.Public) {
 	defer func() {
 		// Flush the SRK
 		flushSRKCmd := FlushContext{createSRKRsp.ObjectHandle}
-		if _, err := flushSRKCmd.Execute(thetpm); err != nil {
+		if err := flushSRKCmd.Execute(thetpm); err != nil {
 			t.Errorf("%v", err)
 		}
 	}()
@@ -266,7 +266,7 @@ func unsealingTest(t *testing.T, srkTemplate tpm2b.Public) {
 	defer func() {
 		// Flush the blob
 		flushBlobCmd := FlushContext{loadBlobRsp.ObjectHandle}
-		if _, err := flushBlobCmd.Execute(thetpm); err != nil {
+		if err := flushBlobCmd.Execute(thetpm); err != nil {
 			t.Errorf("%v", err)
 		}
 	}()

--- a/direct/tpm2/sealing_test.go
+++ b/direct/tpm2/sealing_test.go
@@ -16,7 +16,7 @@ import (
 
 // Test creating and unsealing a sealed data blob with a password and HMAC.
 func TestUnseal(t *testing.T) {
-	templates := map[string]tpm2b.Public{
+	templates := map[string]tpmt.Public{
 		"RSA": templates.RSASRKTemplate,
 		"ECC": templates.ECCSRKTemplate,
 	}
@@ -29,7 +29,7 @@ func TestUnseal(t *testing.T) {
 	}
 }
 
-func unsealingTest(t *testing.T, srkTemplate tpm2b.Public) {
+func unsealingTest(t *testing.T, srkTemplate tpmt.Public) {
 	thetpm, err := simulator.OpenSimulator()
 	if err != nil {
 		t.Fatalf("could not connect to TPM simulator: %v", err)
@@ -48,7 +48,9 @@ func unsealingTest(t *testing.T, srkTemplate tpm2b.Public) {
 				},
 			},
 		},
-		InPublic: srkTemplate,
+		InPublic: tpm2b.Public{
+			PublicArea: srkTemplate,
+		},
 	}
 	createSRKRsp, err := createSRKCmd.Execute(thetpm)
 	if err != nil {
@@ -79,7 +81,7 @@ func unsealingTest(t *testing.T, srkTemplate tpm2b.Public) {
 				UserAuth: tpm2b.Auth{
 					Buffer: auth,
 				},
-				Data: tpm2b.Data{
+				Data: tpm2b.SensitiveData{
 					Buffer: data,
 				},
 			},


### PR DESCRIPTION
This PR introduces a helper called `PolicyCalculator` for calculating TPM policies. Every Policy TPM command now implements an interface called `PolicyCommand` for updating a `PolicyCalculator`. This allows TPM policies to be found without using trial sessions in a TPM.

This PR updates existing TPM command `Execute` functions to simply return `error` values when the response structure is empty. To support the reflection logic (and future likely auditing logic), all the empty response structure definitions still have to exist, but we just won't return them to callers, who will 100% of the time assign them to _.

This PR fixes a couple of typos and missed error conditions. The most interesting of these fixes is that `Execute` will now remind the user when they forgot to add an authorization to an `AuthHandle`, instead of panicking.

This PR also adds the following 22 commands into TPMDirect, approximately doubling the number of supported commands in TPMDirect to 47 out of the 122 commands in the latest TPM specification:

* Shutdown
* Startup
* VerifySignature
* PCR_Extend
* PCR_Event
* PolicySigned
* PolicyOR
* PolicyCommandCode
* PolicyCPHash
* PolicyAuthorize
* PolicyGetDigest
* PolicyNVWritten
* PolicyAuthorizeNV
* NV_DefineSpace
* NV_UndefineSpace
* NV_UndefineSpaceSpecial
* NV_ReadPublic
* NV_Write
* NV_WriteLock
* NV_Read
* LoadExternal
* CreateLoaded

LoadExternal was added because VerifySignature isn't very useful without it, and CreateLoaded was added because it (like LoadExternal) has an "optional" command parameter that needs to be handled correctly. "Optional" parameters are 2Bs that can contain nothing, even if what they normally contain does not have a legal empty serialization: LoadExternal accepts one "optional" and CreateLoaded returns one "optional" - together, their implementation validates the special logic required for these parameters.

This change modifies the templates in the `templates` package to have type `tpmt.Public` instead of `tpm2b.Public`. This is so that they can be used for the contents of `tpm2b.Template` as needed by CreateLoaded.

This change introduces 2 actual go `interface`s for some very special types where, to preserve backwards compatibility, the TPM spec introduced new alternative serializations of existing types for CreateLoaded: 

* the contents of `tpm2b.Template` can be either classic `tpmt.Public` or a slightly modified version, which I have generified as `tpmu.Template`
* the contents of `tpms.SensitiveCreate` can be either classic `tpm2b.SensitiveData` or the label/context pairing in `tpm2b.Derive`, which I have generified as `tpmu.SensitiveCreate`.

These special pseudo-unions need to be assignable from both the "classic" types as well as the special ones depending on the context of CreateLoaded. Making them into interfaces allows callers to write both of these:

```
tpm2.CreateLoaded{
	InPublic: tpm2b.Template{
		Template: tpmt.Public{
			...
```

and

```
tpm2.CreateLoaded{
	InPublic: tpm2b.Template{
		Template: tpmt.Template{
			...
```

This increases the boilerplate for the types, doesn't offer unmarshalling logic, and would be frustrating to scale over time if this weren't a highly special case for this one command. However in this one case, it greatly improves the ergonomics over the alternatives I can think of (for example, making `tpm2b.Template` contain two pointer members and documenting for users that they should only fill one in).

Fun fact about this change: to add the first 20 commands (as well as some other helper functionality), we only needed 300 lines of new structure types, and 600 lines of new command types and methods, and all 900 of these lines were extremely rote, boilerplate implementations. Extrapolating this data (45 lines per command), it should take around 3500 more lines of boilerplate code to implement the rest of the spec. CreateLoaded and LoadExternal required a bit more changes to the marshalling logic, because they introduce "optional" parameters (no other commands have these).