### PR TITLE
Make tpm2 quote functions accept PCR selections for multiple banks

### DIFF
--- a/tpm2/encoding_test.go
+++ b/tpm2/encoding_test.go
@@ -296,7 +296,7 @@ func TestEncodeQuote(t *testing.T) {
 		t.Fatal(err)
 	}
 	toQuote := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x10}
-	cmdBytes, err := encodeQuote(tpmutil.Handle(0x80000001), defaultPassword, toQuote, pcrSelection7, 0x0010)
+	cmdBytes, err := encodeQuote(tpmutil.Handle(0x80000001), defaultPassword, toQuote, []PCRSelection{pcrSelection7}, 0x0010)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -823,13 +823,13 @@ func (ci CertifyInfo) encode() ([]byte, error) {
 
 // QuoteInfo represents a TPMS_QUOTE_INFO structure.
 type QuoteInfo struct {
-	PCRSelection PCRSelection
+	PCRSelection []PCRSelection
 	PCRDigest    tpmutil.U16Bytes
 }
 
 func decodeQuoteInfo(in *bytes.Buffer) (*QuoteInfo, error) {
 	var out QuoteInfo
-	sel, err := decodeOneTPMLPCRSelection(in)
+	sel, err := decodeTPMLPCRSelection(in)
 	if err != nil {
 		return nil, fmt.Errorf("decoding PCRSelection: %v", err)
 	}
@@ -842,7 +842,7 @@ func decodeQuoteInfo(in *bytes.Buffer) (*QuoteInfo, error) {
 }
 
 func (qi QuoteInfo) encode() ([]byte, error) {
-	sel, err := encodeTPMLPCRSelection(qi.PCRSelection)
+	sel, err := encodeTPMLPCRSelection(qi.PCRSelection...)
 	if err != nil {
 		return nil, fmt.Errorf("encoding PCRSelection: %v", err)
 	}

--- a/tpm2/test/tpm2_test.go
+++ b/tpm2/test/tpm2_test.go
@@ -1670,7 +1670,7 @@ func TestQuote(t *testing.T) {
 	}
 	defer FlushContext(rw, keyHandle)
 
-	attestation, signature, err := Quote(rw, keyHandle, emptyPassword, emptyPassword, nil, pcrSelection7, AlgNull)
+	attestation, signature, err := Quote(rw, keyHandle, emptyPassword, emptyPassword, nil, []PCRSelection{pcrSelection7}, AlgNull)
 	if err != nil {
 		t.Fatalf("Quote failed: %v", err)
 	}

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -950,7 +950,7 @@ func UnsealWithSession(rw io.ReadWriter, sessionHandle, itemHandle tpmutil.Handl
 	return decodeUnseal(resp)
 }
 
-func encodeQuote(signingHandle tpmutil.Handle, signerAuth string, toQuote tpmutil.U16Bytes, sel PCRSelection, sigAlg Algorithm) ([]byte, error) {
+func encodeQuote(signingHandle tpmutil.Handle, signerAuth string, toQuote tpmutil.U16Bytes, sel []PCRSelection, sigAlg Algorithm) ([]byte, error) {
 	ha, err := tpmutil.Pack(signingHandle)
 	if err != nil {
 		return nil, err
@@ -963,7 +963,7 @@ func encodeQuote(signingHandle tpmutil.Handle, signerAuth string, toQuote tpmuti
 	if err != nil {
 		return nil, err
 	}
-	pcrs, err := encodeTPMLPCRSelection(sel)
+	pcrs, err := encodeTPMLPCRSelection(sel...)
 	if err != nil {
 		return nil, err
 	}
@@ -988,7 +988,7 @@ func decodeQuote(in []byte) ([]byte, []byte, error) {
 // values, created using a signing TPM key.
 //
 // Returns attestation data and the decoded signature.
-func Quote(rw io.ReadWriter, signingHandle tpmutil.Handle, signerAuth, unused string, toQuote []byte, sel PCRSelection, sigAlg Algorithm) ([]byte, *Signature, error) {
+func Quote(rw io.ReadWriter, signingHandle tpmutil.Handle, signerAuth, unused string, toQuote []byte, sel []PCRSelection, sigAlg Algorithm) ([]byte, *Signature, error) {
 	// TODO: Remove "unused" parameter on next breaking change.
 	attest, sigRaw, err := QuoteRaw(rw, signingHandle, signerAuth, unused, toQuote, sel, sigAlg)
 	if err != nil {
@@ -1003,7 +1003,7 @@ func Quote(rw io.ReadWriter, signingHandle tpmutil.Handle, signerAuth, unused st
 
 // QuoteRaw is very similar to Quote, except that it will return
 // the raw signature in a byte array without decoding.
-func QuoteRaw(rw io.ReadWriter, signingHandle tpmutil.Handle, signerAuth, unused string, toQuote []byte, sel PCRSelection, sigAlg Algorithm) ([]byte, []byte, error) {
+func QuoteRaw(rw io.ReadWriter, signingHandle tpmutil.Handle, signerAuth, unused string, toQuote []byte, sel []PCRSelection, sigAlg Algorithm) ([]byte, []byte, error) {
 	// TODO: Remove "unused" parameter on next breaking change.
 	Cmd, err := encodeQuote(signingHandle, signerAuth, toQuote, sel, sigAlg)
 	if err != nil {


### PR DESCRIPTION
The TPM quote commands accept an array of PCR selections but the go-tpm library did not reflect this in its public API, so I added some brackets and dots here and there.