### PR TITLE
Windows TPM Base Services (TBS) - Implement Tbsi_Get_OwnerAuth

### DIFF
--- a/tpmutil/tbs/tbs_windows.go
+++ b/tpmutil/tbs/tbs_windows.go
@@ -282,6 +282,7 @@ func (context Context) GetOwnerAuth(ownerAuthType OwnerAuthType, ownerAuthBuffer
 	//	);
 	result, _, _ := tbsGetOwnerAuth.Call(
 		uintptr(context),
+		uintptr(uint32(ownerAuthType)),
 		sliceAddress(ownerAuthBuffer),
 		uintptr(unsafe.Pointer(&ownerAuthBufferLen)),
 	)

--- a/tpmutil/tbs/tbs_windows_test.go
+++ b/tpmutil/tbs/tbs_windows_test.go
@@ -58,63 +58,6 @@ func TestGetLogWithNilSlice(t *testing.T) {
 	}
 }
 
-// Get Storage owner authorization delegation blob
-func TestGetStorageOwnerAuth(t *testing.T) {
-	ctx := getContext(t)
-	defer ctx.Close()
-
-	authBufferLength, err := ctx.GetOwnerAuth(Storage20Authorization, nil)
-	if err != nil {
-		t.Fatalf("Failed to get Storage authorization delegation blob size: %v", err)
-	}
-	if authBufferLength <= 0 {
-		t.Fatal("Expected positive Storage authorization delegation blob size")
-	}
-
-	storageOwnerAuth := make([]byte, authBufferLength)
-	if _, err := ctx.GetOwnerAuth(Storage20Authorization, storageOwnerAuth); err != nil {
-		t.Fatalf("Failed to retrieve Storage Authorization delegation blob from the registry: %v", err)
-	}
-}
-
-// Get Endorsement owner authorization delegation blob
-func TestGetEndorsementOwnerAuth(t *testing.T) {
-	ctx := getContext(t)
-	defer ctx.Close()
-
-	authBufferLength, err := ctx.GetOwnerAuth(Endorsement20Authorization, nil)
-	if err != nil {
-		t.Fatalf("Failed to get Endorsement authorization delegation blob size: %v", err)
-	}
-	if authBufferLength <= 0 {
-		t.Fatal("Expected positive Endorsement authorization delegation blob size")
-	}
-
-	endorsementOwnerAuth := make([]byte, authBufferLength)
-	if _, err := ctx.GetOwnerAuth(Endorsement20Authorization, endorsementOwnerAuth); err != nil {
-		t.Fatalf("Failed to retrieve Endorsement Authorization delegation blob from the registry: %v", err)
-	}
-}
-
-// Get Full owner authorization delegation blob
-func TestGetFullOwnerAuth(t *testing.T) {
-	ctx := getContext(t)
-	defer ctx.Close()
-
-	authBufferLength, err := ctx.GetOwnerAuth(FullAuthorization, nil)
-	if err != nil {
-		t.Fatalf("Failed to get Full authorization delegation blob size: %v", err)
-	}
-	if authBufferLength <= 0 {
-		t.Fatal("Expected positive Full authorizaiton delegation blob size")
-	}
-
-	fullOwnerAuth := make([]byte, authBufferLength)
-	if _, err := ctx.GetOwnerAuth(FullAuthorization, fullOwnerAuth); err != nil {
-		t.Fatalf("Failed to retrieve Full Authorization delegation blob from the registry: %v", err)
-	}
-}
-
 // SubmitCommand can handle a nil command buffer.
 func TestSubmitCommandNilCommand(t *testing.T) {
 	ctx := getContext(t)
@@ -166,5 +109,74 @@ func TestSubmitCommandLongResponse(t *testing.T) {
 	expectedGetRandomRawResponse := []byte{128, 1, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0}
 	if !bytes.Equal(rawResponse, expectedGetRandomRawResponse) {
 		t.Fatalf("Got response of %v, expected %v", rawResponse, expectedGetRandomRawResponse)
+	}
+}
+
+// Get Storage owner authorization delegation blob
+func TestGetStorageOwnerAuth(t *testing.T) {
+	ctx := getContext(t)
+	defer ctx.Close()
+
+	authBufferLength, err := ctx.GetOwnerAuth(Storage20Authorization, nil)
+	if err != nil && err != ErrOwnerauthNotFound {
+		t.Fatalf("Failed to get Storage authorization delegation blob size: %v", err)
+	} else if err == ErrOwnerauthNotFound {
+		t.Log("Skipping retrieval of Storage authorization; Delegation blob not available in the registry.")
+		t.SkipNow()
+	}
+
+	storageOwnerAuth := make([]byte, authBufferLength)
+	if _, err := ctx.GetOwnerAuth(Storage20Authorization, storageOwnerAuth); err != nil && err != ErrOwnerauthNotFound {
+		t.Fatalf("Failed to retrieve Storage Authorization delegation blob from the registry: %v", err)
+	} else if err == ErrOwnerauthNotFound {
+		t.Log("Skipping retrieval of Storage authorization; Delegation blob not available in the registry.")
+		t.SkipNow()
+	}
+}
+
+// Get Endorsement owner authorization delegation blob
+func TestGetEndorsementOwnerAuth(t *testing.T) {
+	ctx := getContext(t)
+	defer ctx.Close()
+
+	authBufferLength, err := ctx.GetOwnerAuth(Endorsement20Authorization, nil)
+	if err != nil && err != ErrOwnerauthNotFound {
+		t.Fatalf("Failed to get Endorsement authorization delegation blob size: %v", err)
+	} else if err == ErrOwnerauthNotFound {
+		t.Log("Skipping retrieval of Endorsement authorization; Delegation blob not available in the registry.")
+		t.SkipNow()
+	}
+	if authBufferLength <= 0 {
+		t.Fatal("Expected positive Endorsement authorization delegation blob size")
+	}
+
+	endorsementOwnerAuth := make([]byte, authBufferLength)
+	if _, err := ctx.GetOwnerAuth(Endorsement20Authorization, endorsementOwnerAuth); err != nil && err != ErrOwnerauthNotFound {
+		t.Fatalf("Failed to retrieve Endorsement Authorization delegation blob from the registry: %v", err)
+	} else if err == ErrOwnerauthNotFound {
+		t.Log("Skipping retrieval of Endorsement authorization; Delegation blob not available in the registry.")
+		t.SkipNow()
+	}
+}
+
+// Get Full owner authorization delegation blob
+func TestGetFullOwnerAuth(t *testing.T) {
+	ctx := getContext(t)
+	defer ctx.Close()
+
+	authBufferLength, err := ctx.GetOwnerAuth(FullAuthorization, nil)
+	if err != nil && err != ErrOwnerauthNotFound {
+		t.Fatalf("Failed to get Full authorization delegation blob size: %v", err)
+	} else if err == ErrOwnerauthNotFound {
+		t.Log("Skipping retrieval of Full authorization; Delegation blob not available in the registry.")
+		t.SkipNow()
+	}
+
+	fullOwnerAuth := make([]byte, authBufferLength)
+	if _, err := ctx.GetOwnerAuth(FullAuthorization, fullOwnerAuth); err != nil && err != ErrOwnerauthNotFound {
+		t.Fatalf("Failed to retrieve Full Authorization delegation blob from the registry: %v", err)
+	} else if err == ErrOwnerauthNotFound {
+		t.Log("Skipping retrieval of Full authorization; Delegation blob not available in the registry.")
+		t.SkipNow()
 	}
 }

--- a/tpmutil/tbs/tbs_windows_test.go
+++ b/tpmutil/tbs/tbs_windows_test.go
@@ -118,11 +118,15 @@ func TestGetStorageOwnerAuth(t *testing.T) {
 	defer ctx.Close()
 
 	authBufferLength, err := ctx.GetOwnerAuth(Storage20Authorization, nil)
-	if err != nil && err != ErrOwnerauthNotFound {
-		t.Fatalf("Failed to get Storage authorization delegation blob size: %v", err)
-	} else if err == ErrOwnerauthNotFound {
-		t.Log("Skipping retrieval of Storage authorization; Delegation blob not available in the registry.")
+	if err == ErrOwnerauthNotFound || err == ErrInternalError {
+		expectedErrorHint := "An internal error occurred.  Are you running with Administrative permissions?"
+		if err == ErrOwnerauthNotFound {
+			expectedErrorHint = "Delegation blob not available in the registry."
+		}
+		t.Logf("Skipping retrieval of Storage authorization; %v", expectedErrorHint)
 		t.SkipNow()
+	} else if err != nil {
+		t.Fatalf("Failed to get Storage authorization delegation blob size: %v", err)
 	}
 
 	storageOwnerAuth := make([]byte, authBufferLength)
@@ -140,11 +144,15 @@ func TestGetEndorsementOwnerAuth(t *testing.T) {
 	defer ctx.Close()
 
 	authBufferLength, err := ctx.GetOwnerAuth(Endorsement20Authorization, nil)
-	if err != nil && err != ErrOwnerauthNotFound {
-		t.Fatalf("Failed to get Endorsement authorization delegation blob size: %v", err)
-	} else if err == ErrOwnerauthNotFound {
-		t.Log("Skipping retrieval of Endorsement authorization; Delegation blob not available in the registry.")
+	if err == ErrOwnerauthNotFound || err == ErrInternalError {
+		expectedErrorHint := "An internal error occurred.  Are you running with Administrative permissions?"
+		if err == ErrOwnerauthNotFound {
+			expectedErrorHint = "Delegation blob not available in the registry."
+		}
+		t.Logf("Skipping retrieval of Endorsement authorization; %v", expectedErrorHint)
 		t.SkipNow()
+	} else if err != nil {
+		t.Fatalf("Unexpected error occurred when retrieving Endorsement authorization delegation blob size: %v", err)
 	}
 	if authBufferLength <= 0 {
 		t.Fatal("Expected positive Endorsement authorization delegation blob size")
@@ -153,9 +161,6 @@ func TestGetEndorsementOwnerAuth(t *testing.T) {
 	endorsementOwnerAuth := make([]byte, authBufferLength)
 	if _, err := ctx.GetOwnerAuth(Endorsement20Authorization, endorsementOwnerAuth); err != nil && err != ErrOwnerauthNotFound {
 		t.Fatalf("Failed to retrieve Endorsement Authorization delegation blob from the registry: %v", err)
-	} else if err == ErrOwnerauthNotFound {
-		t.Log("Skipping retrieval of Endorsement authorization; Delegation blob not available in the registry.")
-		t.SkipNow()
 	}
 }
 
@@ -165,18 +170,19 @@ func TestGetFullOwnerAuth(t *testing.T) {
 	defer ctx.Close()
 
 	authBufferLength, err := ctx.GetOwnerAuth(FullAuthorization, nil)
-	if err != nil && err != ErrOwnerauthNotFound {
-		t.Fatalf("Failed to get Full authorization delegation blob size: %v", err)
-	} else if err == ErrOwnerauthNotFound {
-		t.Log("Skipping retrieval of Full authorization; Delegation blob not available in the registry.")
+	if err == ErrOwnerauthNotFound || err == ErrInternalError {
+		expectedErrorHint := "An internal error occurred.  Are you running with Administrative permissions?"
+		if err == ErrOwnerauthNotFound {
+			expectedErrorHint = "Delegation blob not available in the registry."
+		}
+		t.Logf("Skipping retrieval of Full authorization; %v", expectedErrorHint)
 		t.SkipNow()
+	} else if err != nil {
+		t.Fatalf("Unexpected error occurred when retrieving Full authorization delegation blob size: %v", err)
 	}
 
 	fullOwnerAuth := make([]byte, authBufferLength)
 	if _, err := ctx.GetOwnerAuth(FullAuthorization, fullOwnerAuth); err != nil && err != ErrOwnerauthNotFound {
 		t.Fatalf("Failed to retrieve Full Authorization delegation blob from the registry: %v", err)
-	} else if err == ErrOwnerauthNotFound {
-		t.Log("Skipping retrieval of Full authorization; Delegation blob not available in the registry.")
-		t.SkipNow()
 	}
 }

--- a/tpmutil/tbs/tbs_windows_test.go
+++ b/tpmutil/tbs/tbs_windows_test.go
@@ -58,6 +58,63 @@ func TestGetLogWithNilSlice(t *testing.T) {
 	}
 }
 
+// Get Storage owner authorization delegation blob
+func TestGetStorageOwnerAuth(t *testing.T) {
+	ctx := getContext(t)
+	defer ctx.Close()
+
+	authBufferLength, err := ctx.GetOwnerAuth(Storage20Authorization, nil)
+	if err != nil {
+		t.Fatalf("Failed to get Storage authorization delegation blob size: %v", err)
+	}
+	if authBufferLength <= 0 {
+		t.Fatal("Expected positive Storage authorization delegation blob size")
+	}
+
+	storageOwnerAuth := make([]byte, authBufferLength)
+	if _, err := ctx.GetOwnerAuth(Storage20Authorization, storageOwnerAuth); err != nil {
+		t.Fatalf("Failed to retrieve Storage Authorization delegation blob from the registry: %v", err)
+	}
+}
+
+// Get Endorsement owner authorization delegation blob
+func TestGetEndorsementOwnerAuth(t *testing.T) {
+	ctx := getContext(t)
+	defer ctx.Close()
+
+	authBufferLength, err := ctx.GetOwnerAuth(Endorsement20Authorization, nil)
+	if err != nil {
+		t.Fatalf("Failed to get Endorsement authorization delegation blob size: %v", err)
+	}
+	if authBufferLength <= 0 {
+		t.Fatal("Expected positive Endorsement authorization delegation blob size")
+	}
+
+	endorsementOwnerAuth := make([]byte, authBufferLength)
+	if _, err := ctx.GetOwnerAuth(Endorsement20Authorization, endorsementOwnerAuth); err != nil {
+		t.Fatalf("Failed to retrieve Endorsement Authorization delegation blob from the registry: %v", err)
+	}
+}
+
+// Get Full owner authorization delegation blob
+func TestGetFullOwnerAuth(t *testing.T) {
+	ctx := getContext(t)
+	defer ctx.Close()
+
+	authBufferLength, err := ctx.GetOwnerAuth(FullAuthorization, nil)
+	if err != nil {
+		t.Fatalf("Failed to get Full authorization delegation blob size: %v", err)
+	}
+	if authBufferLength <= 0 {
+		t.Fatal("Expected positive Full authorizaiton delegation blob size")
+	}
+
+	fullOwnerAuth := make([]byte, authBufferLength)
+	if _, err := ctx.GetOwnerAuth(FullAuthorization, fullOwnerAuth); err != nil {
+		t.Fatalf("Failed to retrieve Full Authorization delegation blob from the registry: %v", err)
+	}
+}
+
 // SubmitCommand can handle a nil command buffer.
 func TestSubmitCommandNilCommand(t *testing.T) {
 	ctx := getContext(t)


### PR DESCRIPTION
Implementation and tests for `TBS.h` function [Tbsi_Get_OwnerAuth](https://docs.microsoft.com/en-us/windows/win32/api/tbs/nf-tbs-tbsi_get_ownerauth).

Fixes #275 