### PR TITLE
Define the structure related to ECDAA

### DIFF
--- a/direct/structures/internal/structures.go
+++ b/direct/structures/internal/structures.go
@@ -1044,7 +1044,7 @@ type TPMSSchemeHash struct {
 	HashAlg TPMIAlgHash
 }
 
-// TPM represents a TPMS_SCHEME_ECDAA.
+// TPMSSchemeECDAA represents a TPMS_SCHEME_ECDAA.
 // See definition in Part 2: Structures, section 11.1.18.
 type TPMSSchemeECDAA struct {
 	// the hash algorithm used to digest the message

--- a/direct/structures/internal/structures.go
+++ b/direct/structures/internal/structures.go
@@ -1044,7 +1044,7 @@ type TPMSSchemeECDAA struct {
 }
 
 // TPMIAlgKeyedHashScheme represents a TPMI_ALG_KEYEDHASH_SCHEME.
-// See definition in Part 2: Structures, section 11.1.10.
+// See definition in Part 2: Structures, section 11.1.19.
 type TPMIAlgKeyedHashScheme = TPMAlgID
 
 // TPMSSchemeHMAC represents a TPMS_SCHEME_HMAC.

--- a/direct/structures/internal/structures.go
+++ b/direct/structures/internal/structures.go
@@ -1033,6 +1033,16 @@ type TPMSSchemeHash struct {
 	HashAlg TPMIAlgHash
 }
 
+// TPM represents a TPMS_SCHEME_ECDAA.
+// See definition in Part 2: Structures, section 11.1.18.
+type TPMSSchemeECDAA struct {
+	// the hash algorithm used to digest the message
+	HashAlg TPMIAlgHash
+	// the counter value that is used between TPM2_Commit()
+	// and the sign operation
+	Count uint16
+}
+
 // TPMIAlgKeyedHashScheme represents a TPMI_ALG_KEYEDHASH_SCHEME.
 // See definition in Part 2: Structures, section 11.1.10.
 type TPMIAlgKeyedHashScheme = TPMAlgID

--- a/direct/structures/tpms/tpms.go
+++ b/direct/structures/tpms/tpms.go
@@ -103,6 +103,10 @@ type SensitiveCreate = internal.TPMSSensitiveCreate
 // See definition in Part 2: Structures, section 11.1.17.
 type SchemeHash = internal.TPMSSchemeHash
 
+// SchemeECDAA represents a TPMS_SCHEME_ECDAA.
+// See definition in Part 2: Structures, section 11.1.18.
+type SchemeECDAA = internal.TPMSSchemeECDAA
+
 // SchemeHMAC represents a TPMS_SCHEME_HMAC.
 // See definition in Part 2: Structures, section 11.1.20.
 type SchemeHMAC = internal.TPMSSchemeHMAC


### PR DESCRIPTION
Add the structure related to ECDAA. 
Please read https://github.com/google/go-tpm/pull/285#issuecomment-1170212446 .

- [x] TPMS_SCHEME_ECDAA added 
- [x] A type alias for internal.TPMSSchemeECDAA as tpms.SchemeECDAA 
