### PR TITLE
Check if are available before calling the function

### DIFF
--- a/tpmutil/tbs/tbs_windows.go
+++ b/tpmutil/tbs/tbs_windows.go
@@ -161,6 +161,9 @@ func GetDeviceInfo() (*DeviceInfo, error) {
 	//   UINT32 Size,
 	//   PVOID  Info
 	// );
+	if err := tbsGetDeviceInfo.Find(); err != nil {
+		return nil, err
+	}
 	result, _, _ := tbsGetDeviceInfo.Call(
 		unsafe.Sizeof(info),
 		uintptr(unsafe.Pointer(&info)),
@@ -180,6 +183,9 @@ func CreateContext(version Version, flag Flag) (Context, error) {
 	//   _In_  PCTBS_CONTEXT_PARAMS pContextParams,
 	//   _Out_ PTBS_HCONTEXT        *phContext
 	// );
+	if err := tbsCreateContext.Find(); err != nil {
+		return context, err
+	}
 	result, _, _ := tbsCreateContext.Call(
 		uintptr(unsafe.Pointer(&params)),
 		uintptr(unsafe.Pointer(&context)),
@@ -193,6 +199,9 @@ func (context Context) Close() error {
 	// TBS_RESULT Tbsip_Context_Close(
 	//   _In_ TBS_HCONTEXT hContext
 	// );
+	if err := tbsContextClose.Find(); err != nil {
+		return err
+	}
 	result, _, _ := tbsContextClose.Call(uintptr(context))
 	return getError(result)
 }
@@ -218,6 +227,9 @@ func (context Context) SubmitCommand(
 	//   _Out_         PBYTE                *pabResult,
 	//   _Inout_       UINT32               *pcbOutput
 	// );
+	if err := tbsSubmitCommand.Find(); err != nil {
+		return 0, err
+	}
 	result, _, _ := tbsSubmitCommand.Call(
 		uintptr(context),
 		uintptr(commandLocalityZero),
@@ -243,6 +255,9 @@ func (context Context) GetTCGLog(logBuffer []byte) (uint32, error) {
 	//   PBYTE        pOutputBuf,
 	//   PUINT32      pOutputBufLen
 	// );
+	if err := tbsGetTCGLog.Find(); err != nil {
+		return 0, err
+	}
 	result, _, _ := tbsGetTCGLog.Call(
 		uintptr(context),
 		sliceAddress(logBuffer),


### PR DESCRIPTION
For windows, each function is available on different OS versions.
To avoid panic, Check if are available before calling the function.