### PR TITLE
Allow callers to omit handles from commands when RH_NULL

### DIFF
--- a/tpm2/test/create_loaded_test.go
+++ b/tpm2/test/create_loaded_test.go
@@ -74,6 +74,10 @@ func TestCreateLoaded(t *testing.T) {
 			ParentHandle: TPMRHEndorsement,
 			InPublic:     New2BTemplate(&ECCEKTemplate),
 		},
+		"NoParentPrimaryKey": {
+			// Make the object in the null hierarchy and ensure that go-tpm supports not providing the parent handle at all.
+			InPublic: New2BTemplate(&ECCEKTemplate),
+		},
 		"OrdinaryKey": {
 			ParentHandle: TPMRHOwner,
 			InSensitive: TPM2BSensitiveCreate{

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -126,10 +126,10 @@ type StartupResponse struct{}
 type StartAuthSession struct {
 	// handle of a loaded decrypt key used to encrypt salt
 	// may be TPM_RH_NULL
-	TPMKey handle `gotpm:"handle,nullable"`
+	TPMKey handle `gotpm:"handle"`
 	// entity providing the authValue
 	// may be TPM_RH_NULL
-	Bind handle `gotpm:"handle,nullable"`
+	Bind handle `gotpm:"handle"`
 	// initial nonceCaller, sets nonceTPM size for the session
 	// shall be at least 16 octets
 	NonceCaller TPM2BNonce
@@ -392,7 +392,7 @@ type UnsealResponse struct {
 type CreateLoaded struct {
 	// Handle of a transient storage key, a persistent storage key,
 	// TPM_RH_ENDORSEMENT, TPM_RH_OWNER, TPM_RH_PLATFORM+{PP}, or TPM_RH_NULL
-	ParentHandle handle `gotpm:"handle,auth,nullable"`
+	ParentHandle handle `gotpm:"handle,auth"`
 	// the sensitive data, see TPM 2.0 Part 1 Sensitive Values
 	InSensitive TPM2BSensitiveCreate
 	// the public template


### PR DESCRIPTION
I observed that the both the following will fail:

```go
tpm2StartAuthSession{
  SessionType: tpm2.TPMSETrial,
  AuthHash:    tpm2.TPMAlgSHA256,
  NonceCaller: tpm2.TPM2BNonce{
	  Buffer: make([]byte, 16),
  },
}.Execute(tpm)
```

```go
tpm2.CreateLoaded{
  InPublic: someTemplate,
}.Execute(tpm)
```

with a message like

```
'handle'-tagged member of 'tpm2.StartAuthSession' was of type 'tpm2.handle', which does not satisfy handle
```

because their `handle` tagged values of type `tpm2.handle`, while marked `nullable`, were failing type assertions to `handle` during the reflection based marshalling.

Investigating this led me to learn that type assertions on nil-valued interface-typed variables (such as `handle`-typed TPM command struct fields) will fail due to the design of the language.

To improve the usability of go-tpm and allow callers to leave out handles in commands when NULL is desired, this change adds logic to treat any nil-valued interface-typed command variable (when annotated with `gotpm:handle`) as `TPM_RH_NULL`. This allows us to remove the `nullable` annotation from those fields, which makes sense. It's an interface, the user can always (try to) pass nil, and this should always mean `TPM_RH_NULL`.

