### PR TITLE
Fix the mistake of signature algorithm number

### DIFF
--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -2450,7 +2450,7 @@ func (u *TPMUSignature) ECDSA() (*TPMSSignatureECC, error) {
 
 // ECDAA returns the 'ecdaa' member of the union.
 func (u *TPMUSignature) ECDAA() (*TPMSSignatureECC, error) {
-	if u.selector == TPMAlgRSASSA {
+	if u.selector == TPMAlgECDAA {
 		return u.contents.(*TPMSSignatureECC), nil
 	}
 	return nil, fmt.Errorf("did not contain ecdaa (selector value was %v)", u.selector)


### PR DESCRIPTION
`TPMUSignature.ECDAA()` incorrectly checked whether the signature algorithm is `RSASSA`, so this commit fixes it.

Update: `TPMAlgRSASSA` => `TPMAlgECDAA`