### PR TITLE
add TPM2_PolicyDuplicationSelect

### DIFF
--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1272,6 +1272,40 @@ func (cmd PolicyAuthValue) Update(policy *PolicyCalculator) error {
 // PolicyAuthValueResponse is the response from TPM2_PolicyAuthValue.
 type PolicyAuthValueResponse struct{}
 
+// PolicyDuplicationSelect is the input to TPM2_PolicyDuplicationSelect.
+// See definition in Part 3, Commands, section 23.15.
+type PolicyDuplicationSelect struct {
+	// handle for the policy session being extended
+	PolicySession handle `gotpm:"handle"`
+	ObjectName    TPM2BName
+	NewParentName TPM2BName
+	IncludeObject TPMIYesNo
+}
+
+// Command implements the Command interface.
+func (PolicyDuplicationSelect) Command() TPMCC { return TPMCCPolicyDuplicationSelect }
+
+// Execute executes the command and returns the response.
+func (cmd PolicyDuplicationSelect) Execute(t transport.TPM, s ...Session) (*PolicyDuplicationSelectResponse, error) {
+	var rsp PolicyDuplicationSelectResponse
+	err := execute[PolicyDuplicationSelectResponse](t, cmd, &rsp, s...)
+	if err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+// Update implements the PolicyDuplicationSelect interface.
+func (cmd PolicyDuplicationSelect) Update(policy *PolicyCalculator) error {
+	if cmd.IncludeObject {
+		return policy.Update(TPMCCPolicyDuplicationSelect, cmd.ObjectName.Buffer, cmd.NewParentName.Buffer, cmd.IncludeObject)
+	}
+	return policy.Update(TPMCCPolicyDuplicationSelect, cmd.NewParentName.Buffer, cmd.IncludeObject)
+}
+
+// PolicyDuplicationSelectResponse is the response from TPM2_PolicyDuplicationSelect.
+type PolicyDuplicationSelectResponse struct{}
+
 // PolicyNV is the input to TPM2_PolicyNV.
 // See definition in Part 3, Commands, section 23.9.
 type PolicyNV struct {


### PR DESCRIPTION
Adds `TPM2_PolicyDuplicationSelect` as described in

[pg 247 23.15 TPM2_PolicyDuplicationSelect](https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-3-Commands-01.38.pdf)

Specifically, this allows for direct control [where the duplication can occur](https://github.com/tpm2-software/tpm2-tools/blob/master/man/tpm2_duplicate.1.md#example-4-exporting-an-hmac-key-for-a-remote-tpm-and-restrict-it-from-further-exports)

the test cases included here are basic.  i can add an end-to-end gist where a key with this policy is created and imported on a second TPM (todo is  the -ve test where its on a 3rd unauthorized TPM )

@chrisfenner