### PR TITLE
Add TPMFW (firmware) handles and FirmwareLimited attribute to TPMAObject 

### DIFF
--- a/tpm2/constants.go
+++ b/tpm2/constants.go
@@ -652,13 +652,17 @@ type TPMHandle uint32
 
 // TPMHandle values come from Part 2: Structures, section 7.4.
 const (
-	TPMRHOwner       TPMHandle = 0x40000001
-	TPMRHNull        TPMHandle = 0x40000007
-	TPMRSPW          TPMHandle = 0x40000009
-	TPMRHLockout     TPMHandle = 0x4000000A
-	TPMRHEndorsement TPMHandle = 0x4000000B
-	TPMRHPlatform    TPMHandle = 0x4000000C
-	TPMRHPlatformNV  TPMHandle = 0x4000000D
+	TPMRHOwner         TPMHandle = 0x40000001
+	TPMRHNull          TPMHandle = 0x40000007
+	TPMRSPW            TPMHandle = 0x40000009
+	TPMRHLockout       TPMHandle = 0x4000000A
+	TPMRHEndorsement   TPMHandle = 0x4000000B
+	TPMRHPlatform      TPMHandle = 0x4000000C
+	TPMRHPlatformNV    TPMHandle = 0x4000000D
+	TPMRHFWOwner       TPMHandle = 0x40000140
+	TPMRHFWEndorsement TPMHandle = 0x40000141
+	TPMRHFWPlatform    TPMHandle = 0x40000142
+	TPMRHFWNull        TPMHandle = 0x40000143
 )
 
 // TPMNT represents a TPM_NT.

--- a/tpm2/structures.go
+++ b/tpm2/structures.go
@@ -208,6 +208,9 @@ type TPMAObject struct {
 	// be with an HMAC session or with a password using the authValue
 	// of the object or a policy session.
 	AdminWithPolicy bool `gotpm:"bit=7"`
+	// SET (1): The object exists only within a firmware-limited hierarchy.
+	// CLEAR (0): The object can exist outside a firmware-limited hierarchy.
+	FirmwareLimited bool `gotpm:"bit=8"`
 	// SET (1): The object is not subject to dictionary attack
 	// protections.
 	// CLEAR (0): The object is subject to dictionary attack

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -4,7 +4,6 @@ package tpm2
 import (
 	"bytes"
 	"encoding/binary"
-
 	"github.com/google/go-tpm/tpm2/transport"
 )
 
@@ -1542,7 +1541,8 @@ type PolicyAuthorizeNVResponse struct{}
 // See definition in Part 3, Commands, section 24.1
 type CreatePrimary struct {
 	// TPM_RH_ENDORSEMENT, TPM_RH_OWNER, TPM_RH_PLATFORM+{PP},
-	// or TPM_RH_NULL
+	// TPM_RH_NULL, TPM_RH_FW_ENDORSEMENT, TPM_RH_FW_OWNER
+	// TPM_RH_FW_PLATFORM+{PP}  or TPM_RH_FW_NULL
 	PrimaryHandle handle `gotpm:"handle,auth"`
 	// the sensitive data
 	InSensitive TPM2BSensitiveCreate


### PR DESCRIPTION
Add TPMFW (firmware) handles to go_tpm from updated TCG specs at https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-1.83-Part-2-Structures.pdf#page83 and add FirmwareLimited attribute to TPMAObject and allow to the validation to accept keys with and without the bit set