### PR TITLE
Unify ECC public key helpers on ECDHPub and ECDSAPub

### DIFF
--- a/tpm2/crypto.go
+++ b/tpm2/crypto.go
@@ -141,30 +141,6 @@ func ECDHPub(parms *TPMSECCParms, pub *TPMSECCPoint) (*ecdh.PublicKey, error) {
 	return pubKey.ECDH()
 }
 
-// ECDHPubKey converts a TPM ECC public key into one recognized by the ecdh package
-func ECDHPubKey(curve ecdh.Curve, pub *TPMSECCPoint) (*ecdh.PublicKey, error) {
-
-	var c elliptic.Curve
-	switch curve {
-	case ecdh.P256():
-		c = elliptic.P256()
-	case ecdh.P384():
-		c = elliptic.P384()
-	case ecdh.P521():
-		c = elliptic.P521()
-	default:
-		return nil, fmt.Errorf("unknown curve: %v", curve)
-	}
-
-	pubKey := ecdsa.PublicKey{
-		Curve: c,
-		X:     big.NewInt(0).SetBytes(pub.X.Buffer),
-		Y:     big.NewInt(0).SetBytes(pub.Y.Buffer),
-	}
-
-	return pubKey.ECDH()
-}
-
 // ECCPoint returns an uncompressed ECC Point
 func ECCPoint(pubKey *ecdh.PublicKey) (*big.Int, *big.Int, error) {
 	b := pubKey.Bytes()

--- a/tpm2/sessions.go
+++ b/tpm2/sessions.go
@@ -428,9 +428,9 @@ func getEncryptedSaltECC(nameAlg TPMIAlgHash, parms *TPMSECCParms, pub *TPMSECCP
 	if err != nil {
 		return nil, nil, fmt.Errorf("ecc salt: param curve: %w", err)
 	}
-	eccPub, err := ECDHPubKey(curve, pub)
+	eccPub, err := ECDHPub(parms, pub)
 	if err != nil {
-		return nil, nil, fmt.Errorf("ecc salt: unmarshalling tpm ecc key: %w", err)
+		return nil, nil, fmt.Errorf("ecc salt: unmarshaling tpm ecc key: %w", err)
 	}
 
 	// Generate new ECDH key

--- a/tpm2/test/ecdh_test.go
+++ b/tpm2/test/ecdh_test.go
@@ -71,9 +71,13 @@ func TestECDH(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	tpmPubKey, err := ECDHPubKey(curve, tpmPub)
+	eccParms, err := outPub.Parameters.ECCDetail()
 	if err != nil {
-		t.Fatalf("could not unmarshall pubkey: %v", err)
+		t.Fatalf("%v", err)
+	}
+	tpmPubKey, err := ECDHPub(eccParms, tpmPub)
+	if err != nil {
+		t.Fatalf("could not unmarshal pubkey: %v", err)
 	}
 
 	// Create a SW ECDH key


### PR DESCRIPTION
#372 introduced `ECDHPub` based on `ECDHPubKey`, but with a name more aligned with the other `Pub` functions. This PR removes `ECDHPubKey` in favor of `ECDHPub`.