### PR TITLE
Tolerate differences in RSA private key libraries

### DIFF
--- a/tpm2/crypto_test.go
+++ b/tpm2/crypto_test.go
@@ -11,8 +11,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/go-tpm/tpm2/transport"
 	"github.com/google/go-tpm/tpm2/transport/simulator"
 )
@@ -31,14 +29,9 @@ import (
 // by the software implementation validate (which has the effect of confirming
 // that the private exponents are correct).
 func areRSAPrivateKeysEqual(a, b *rsa.PrivateKey) bool {
-	// Tolerate the primes being in different order, and ignore the unexported
-	// fields of big.Int.
-	less := func(a, b *big.Int) bool { return a.Cmp(b) < 1 }
-	opts := []cmp.Option{cmpopts.SortSlices(less), cmpopts.IgnoreUnexported(big.Int{})}
-
 	return a.E == b.E &&
 		a.N.Cmp(b.N) == 0 &&
-		cmp.Diff(a.Primes, b.Primes, opts...) == ""
+		reflect.DeepEqual(a.Primes, b.Primes)
 }
 
 func TestPriv(t *testing.T) {


### PR DESCRIPTION
`GOEXPERIMENT=boringcrypto go test ./... --test.run TestPriv/valid_rsa` fails occasionally due to the fact that the boringcrypto implementation uses the Carmichael function (lambda(N)) instead of Euler's totient function (phi(N)). Sometimes we get lucky (where phi(N) == lambda(N)) and sometimes we don't.

Unfortunately, the TPM RSA private key structure only contains a prime, for compactness. This means that when importing TPM RSA private keys, we have to compute D from the factorization of N ourselves (see crypto.go). This test generates a key in software, converts it into a TPM private key structure, and then checks that the import function returns the same key. Unfortunately, the software key-generation algorithm may disagree with crypto.go's technique (which is currently to use phi(N)).

This change introduces a helper function to the test for comparing RSA private keys by public exponent, modulus, and primes only.