### PR TITLE
Implement TCP TPM protocol

### DIFF
--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1848,6 +1848,27 @@ func (cmd Import) Execute(t transport.TPM, s ...Session) (*ImportResponse, error
 	return &rsp, nil
 }
 
+// ReadClock is the input to TPM2_ReadClock.
+// See definition in Part 3, Commands, section 29.1
+type ReadClock struct{}
+
+// Command implements the Command interface.
+func (ReadClock) Command() TPMCC { return TPMCCReadClock }
+
+// Execute executes the command and returns the response.
+func (cmd ReadClock) Execute(t transport.TPM, s ...Session) (*ReadClockResponse, error) {
+	var rsp ReadClockResponse
+	if err := execute[ReadClockResponse](t, cmd, &rsp, s...); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+// ReadClockResponse is the response from TPM2_ReadClock.
+type ReadClockResponse struct {
+	CurrentTime TPMSTimeInfo
+}
+
 // GetCapability is the input to TPM2_GetCapability.
 // See definition in Part 3, Commands, section 30.2
 type GetCapability struct {

--- a/tpm2/transport/tcp/tcp.go
+++ b/tpm2/transport/tcp/tcp.go
@@ -1,0 +1,263 @@
+// Package tcp provides access to a TPM over TCP.
+package tcp
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+)
+
+var (
+	ErrPlatformFailed = errors.New("platform command failed")
+	ErrTPMFailed      = errors.New("TPM command failed")
+	ErrResponseTooBig = errors.New("response too big")
+	ErrTransport      = errors.New("TCP transport error")
+	ErrEmptyResponse  = errors.New("TPM returned empty response (does it need to be powered on?)")
+)
+
+const (
+	maxBufferSize = 1048576
+)
+
+// The de-facto TPM-over-TCP protocol is defined by the Reference Implementation.
+// See https://github.com/TrustedComputingGroup/TPM/blob/main/TPMCmd/Simulator/include/TpmTcpProtocol.h
+
+type regularCommand uint32
+
+const (
+	tpmHashStart            regularCommand = 5
+	tpmHashData             regularCommand = 6
+	tpmHashEnd              regularCommand = 7
+	tpmSendCommand          regularCommand = 8
+	tpmRemoteHandshake      regularCommand = 15
+	tpmSetAlternativeResult regularCommand = 16
+	tpmSessionEnd           regularCommand = 20
+	tpmStop                 regularCommand = 21
+)
+
+func (c regularCommand) String() string {
+	switch c {
+	case tpmHashStart:
+		return "HASH_START"
+	case tpmHashData:
+		return "HASH_DATA"
+	case tpmHashEnd:
+		return "HASH_END"
+	case tpmSendCommand:
+		return "SEND_COMMAND"
+	case tpmRemoteHandshake:
+		return "REMOTE_HANDSHAKE"
+	case tpmSetAlternativeResult:
+		return "SET_ALTERNATIVE_RESULT"
+	case tpmSessionEnd:
+		return "SESSION_END"
+	case tpmStop:
+		return "STOP"
+	default:
+		return fmt.Sprintf("unknown TPM command (%v)", uint32(c))
+	}
+}
+
+type platformCommand uint32
+
+const (
+	platformPowerOn                 platformCommand = 1
+	platformPowerOff                platformCommand = 2
+	platformPPOn                    platformCommand = 3
+	platformPPOff                   platformCommand = 4
+	platformCancelOn                platformCommand = 9
+	platformCancelOff               platformCommand = 10
+	platformNVOn                    platformCommand = 11
+	platformNVOff                   platformCommand = 12
+	platformKeyCacheOn              platformCommand = 13
+	platformKeyCacheOff             platformCommand = 14
+	platformReset                   platformCommand = 17
+	platformRestart                 platformCommand = 18
+	platformSessionEnd              platformCommand = 20
+	platformStop                    platformCommand = 21
+	platformGetCommandResponseSizes platformCommand = 25
+	platformACTGetSignaled          platformCommand = 26
+	platformTestFailureMode         platformCommand = 30
+	platformSetFWHash               platformCommand = 35
+	platformSetFWSVN                platformCommand = 36
+)
+
+func (c platformCommand) String() string {
+	switch c {
+	case platformPowerOn:
+		return "POWER_ON"
+	case platformPowerOff:
+		return "POWER_OFF"
+	case platformPPOn:
+		return "PP_ON"
+	case platformPPOff:
+		return "PP_OFF"
+	case platformCancelOn:
+		return "CANCEL_ON"
+	case platformCancelOff:
+		return "CANCEL_OFF"
+	case platformNVOn:
+		return "NV_ON"
+	case platformNVOff:
+		return "NV_OFF"
+	case platformKeyCacheOn:
+		return "KEY_CACHE_ON"
+	case platformKeyCacheOff:
+		return "KEY_CACHE_OFF"
+	case platformReset:
+		return "RESET"
+	case platformRestart:
+		return "RESTART"
+	case platformSessionEnd:
+		return "SESSION_END"
+	case platformStop:
+		return "STOP"
+	case platformGetCommandResponseSizes:
+		return "GET_COMMAND_RESPONSE_SIZES"
+	case platformACTGetSignaled:
+		return "ACT_GET_SIGNALED"
+	case platformTestFailureMode:
+		return "TEST_FAILURE_MODE"
+	case platformSetFWHash:
+		return "SET_FW_HASH"
+	case platformSetFWSVN:
+		return "SET_FW_SVN"
+	default:
+		return fmt.Sprintf("unknown platform command (%v)", uint32(c))
+	}
+}
+
+type TPM struct {
+	cmd  *net.TCPConn
+	plat *net.TCPConn
+}
+
+type tpmCommandHeader struct {
+	tcpCommand regularCommand
+	locality   uint8
+	cmdLen     uint32
+}
+
+// Send implements the TPMCloser interface.
+func (t *TPM) Send(cmd []byte) ([]byte, error) {
+	hdr := tpmCommandHeader{
+		tcpCommand: tpmSendCommand,
+		locality:   0,
+		cmdLen:     uint32(len(cmd)),
+	}
+	// Write the header followed by the request
+	if err := binary.Write(t.cmd, binary.BigEndian, hdr); err != nil {
+		return nil, fmt.Errorf("%w: could not send TPM command to service: %v", ErrTransport, err)
+	}
+	if n, err := t.cmd.Write(cmd); err != nil {
+		return nil, fmt.Errorf("%w: could not send TPM command to service: %v", ErrTransport, err)
+	} else if n != len(cmd) {
+		return nil, fmt.Errorf("%w: could not send full TPM command: only sent %v out of %v bytes", ErrTransport, n, len(cmd))
+	}
+
+	// Read the response
+	var rspLen uint32
+	if err := binary.Read(t.cmd, binary.BigEndian, &rspLen); err != nil {
+		return nil, fmt.Errorf("%w: could not read TPM response from service: %v", ErrTransport, err)
+	}
+	if rspLen > maxBufferSize {
+		return nil, fmt.Errorf("%w: response (%v bytes) was bigger than max size (%v bytes)", ErrResponseTooBig, rspLen, maxBufferSize)
+	}
+	rsp := make([]byte, int(rspLen))
+	if n, err := t.cmd.Read(rsp); err != nil {
+		return nil, fmt.Errorf("%w: could not read TPM response from service: %v", ErrTransport, err)
+	} else if n != len(rsp) {
+		return nil, fmt.Errorf("%w: could not read full TPM response: only got %v out of %v bytes", ErrTransport, n, len(rsp))
+	}
+	// The server also provides a TCP error code at the end.
+	var rspCode uint32
+	if err := binary.Read(t.cmd, binary.BigEndian, &rspCode); err != nil {
+		return nil, fmt.Errorf("%w: %v returned %v", ErrTPMFailed, hdr.tcpCommand, rspCode)
+	}
+	if rspLen == 0 {
+		return nil, ErrEmptyResponse
+	}
+	return rsp, nil
+}
+
+// Close implements the TPMCloser interface.
+func (t *TPM) Close() error {
+	return errors.Join(t.cmd.Close(), t.plat.Close())
+}
+
+// PowerOn powers on the TPM.
+// Note: This is distinct from sending the TPM2_Startup command.
+func (t *TPM) PowerOn() error {
+	return errors.Join(t.sendBasicPlatformCommand(platformPowerOn),
+		t.sendBasicPlatformCommand(platformNVOn))
+}
+
+// PowerOff powers off the TPM.
+func (t *TPM) PowerOff() error {
+	return errors.Join(t.sendBasicPlatformCommand(platformPowerOff),
+		t.sendBasicPlatformCommand(platformNVOff))
+}
+
+// Reset power-cycles the TPM if it is already on. If it is not already on,
+// nothing happens.
+func (t *TPM) Reset() error {
+	return t.sendBasicPlatformCommand(platformReset)
+}
+
+// Config provides the connection information for a running TCP TPM.
+type Config struct {
+	// CommandAddress is the full host:port address of the Command server, e.g.,
+	// "localhost:2321"
+	CommandAddress string
+	// CommandAddress is the full host:port address of the Platform server, e.g.,
+	// "localhost:2322"
+	PlatformAddress string
+}
+
+func resolveAndConnect(addr string) (*net.TCPConn, error) {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve %q: %w", addr, err)
+	}
+
+	conn, err := net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		return nil, fmt.Errorf("could not dial %q: %w", addr, err)
+	}
+	return conn, nil
+}
+
+// Open opens a connection to the TPM. It may still need to be powered on using PowerOn().
+func Open(config Config) (*TPM, error) {
+	cmd, err := resolveAndConnect(config.CommandAddress)
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to command service at %q: %w", config.CommandAddress, err)
+	}
+	plat, err := resolveAndConnect(config.PlatformAddress)
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to platform service at %q: %w", config.PlatformAddress, err)
+	}
+
+	return &TPM{
+		cmd:  cmd,
+		plat: plat,
+	}, nil
+}
+
+// sendBasicPlatformCommand sends a command to the platform service. This only
+// supports 'basic' commands (i.e., send just a command code, receive just a
+// response code).
+func (t *TPM) sendBasicPlatformCommand(cmd platformCommand) error {
+	if err := binary.Write(t.plat, binary.BigEndian, cmd); err != nil {
+		return fmt.Errorf("could not write %v to platform service: %w", cmd, err)
+	}
+	var result uint32
+	if err := binary.Read(t.plat, binary.BigEndian, &result); err != nil {
+		return fmt.Errorf("could not read %v result from platform service: %w", cmd, err)
+	}
+	if result != 0 {
+		return fmt.Errorf("%w: %v returned %v", ErrPlatformFailed, cmd, result)
+	}
+	return nil
+}

--- a/tpm2/transport/tcp/tcp_test.go
+++ b/tpm2/transport/tcp/tcp_test.go
@@ -14,6 +14,14 @@ var (
 	platAddr = flag.String("plat_addr", "", "platform port (e.g., 'localhost:2322')")
 )
 
+// The tests in this file are skipped unless the flags above are provided.
+// To run the tests:
+// Fetch the TPM reference code at https://github.com/trustedcomputinggroup/tpm
+// Build the simulator per the instructions for your platform
+// In one shell, run the simulator, e.g., TPMCmd/Simulator/src/tpm2-simulator
+// In the other, run the tests, e.g.:
+//   go test --cmd_addr localhost:2321 --plat_addr localhost:2322
+
 // Helper to open the TPM based on command-line flags passed to the test, or skip.
 func getTPM(t *testing.T, powerOnStartUp bool) *TPM {
 	t.Helper()
@@ -162,7 +170,7 @@ func TestResetRestart(t *testing.T) {
 	}
 	if clock2.CurrentTime.ClockInfo.ResetCount != clock1.CurrentTime.ClockInfo.ResetCount {
 		t.Errorf("resetCount after Restart was %v, want %v",
-			clock1.CurrentTime.ClockInfo.ResetCount,
+			clock2.CurrentTime.ClockInfo.ResetCount,
 			clock1.CurrentTime.ClockInfo.ResetCount)
 	}
 

--- a/tpm2/transport/tcp/tcp_test.go
+++ b/tpm2/transport/tcp/tcp_test.go
@@ -1,0 +1,179 @@
+package tcp
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"testing"
+
+	"github.com/google/go-tpm/tpm2"
+)
+
+var (
+	cmdAddr  = flag.String("cmd_addr", "", "command port (e.g., 'localhost:2321')")
+	platAddr = flag.String("plat_addr", "", "platform port (e.g., 'localhost:2322')")
+)
+
+// Helper to open the TPM based on command-line flags passed to the test, or skip.
+func getTPM(t *testing.T, powerOnStartUp bool) *TPM {
+	t.Helper()
+	flag.Parse()
+
+	if *cmdAddr == "" || *platAddr == "" {
+		t.Skipf("TPM simulator not provided, skipping test")
+	}
+
+	tpm, err := Open(Config{
+		CommandAddress:  *cmdAddr,
+		PlatformAddress: *platAddr,
+	})
+	if err != nil {
+		t.Fatalf("Open() = %v", err)
+	}
+
+	if err := tpm.PowerOff(); err != nil {
+		t.Fatalf("PowerOff() = %v", err)
+	}
+
+	if powerOnStartUp {
+		if err := tpm.PowerOn(); err != nil {
+			t.Fatalf("PowerOn() = %v", err)
+		}
+		_, err := tpm2.Startup{
+			StartupType: tpm2.TPMSUClear,
+		}.Execute(tpm)
+		if err != nil {
+			t.Fatalf("Startup() = %v", err)
+		}
+	}
+
+	return tpm
+}
+
+// Helper to let us easily test that closing the TPM doesn't return any errors.
+func closeTPM(t *testing.T, tpm *TPM) {
+	t.Helper()
+	if err := tpm.Close(); err != nil {
+		t.Fatalf("Close() = %v", err)
+	}
+}
+
+func TestPowerOnOff(t *testing.T) {
+	tpm := getTPM(t, false)
+	defer closeTPM(t, tpm)
+
+	// The simulator starts out powered off, but maybe the simulator was
+	// running before we started this test.
+	// Ensure it is off at the start of the test.
+	if err := tpm.PowerOff(); err != nil {
+		t.Fatalf("PowerOff() = %v", err)
+	}
+
+	// Check that we return the expected error for a powered-off TPM.
+	_, err := tpm2.Startup{
+		StartupType: tpm2.TPMSUClear,
+	}.Execute(tpm)
+	if !errors.Is(err, ErrEmptyResponse) {
+		t.Fatalf("Startup() before PowerOn() = %v, want %v", err, ErrEmptyResponse)
+	}
+
+	// Power on the TPM.
+	if err := tpm.PowerOn(); err != nil {
+		t.Fatalf("PowerOn() = %v", err)
+	}
+
+	// Check that the TPM now reports it needs to be started up.
+	_, err = tpm2.GetRandom{
+		BytesRequested: 16,
+	}.Execute(tpm)
+	if !errors.Is(err, tpm2.TPMRCInitialize) {
+		t.Errorf("GetRandom() = %v, want %v", err, tpm2.TPMRCInitialize)
+	}
+
+	_, err = tpm2.Startup{
+		StartupType: tpm2.TPMSUClear,
+	}.Execute(tpm)
+	if err != nil {
+		t.Errorf("Startup() = %v", err)
+	}
+
+	rnd, err := tpm2.GetRandom{
+		BytesRequested: 16,
+	}.Execute(tpm)
+	if err != nil {
+		t.Errorf("GetRandom() = %v", err)
+	}
+	if bytes.Equal(rnd.RandomBytes.Buffer, make([]byte, 16)) {
+		t.Errorf("GetRandom() = %x, expected random bytes", rnd.RandomBytes.Buffer)
+	}
+}
+
+// Helper to perform a restart ("warm reboot") or reset ("cold reboot") of the TPM.
+func rebootTPM(t *testing.T, tpm *TPM, shutdownType tpm2.TPMSU) {
+	t.Helper()
+
+	_, err := tpm2.Shutdown{
+		ShutdownType: shutdownType,
+	}.Execute(tpm)
+	if err != nil {
+		t.Fatalf("Shutdown() = %v", err)
+	}
+	if err := tpm.Reset(); err != nil {
+		t.Fatalf("Reset() = %v", err)
+	}
+	_, err = tpm2.Startup{
+		StartupType: shutdownType,
+	}.Execute(tpm)
+	if err != nil {
+		t.Fatalf("Startup() = %v", err)
+	}
+}
+
+func TestResetRestart(t *testing.T) {
+	tpm := getTPM(t, true)
+	defer closeTPM(t, tpm)
+
+	clock1, err := tpm2.ReadClock{}.Execute(tpm)
+	if err != nil {
+		t.Fatalf("ReadClock() = %v", err)
+	}
+
+	// Perform a TPM Restart (SU_STATE)
+	rebootTPM(t, tpm, tpm2.TPMSUState)
+
+	clock2, err := tpm2.ReadClock{}.Execute(tpm)
+	if err != nil {
+		t.Fatalf("ReadClock() = %v", err)
+	}
+
+	// Perform a TPM Reset (SU_CLEAR)
+	rebootTPM(t, tpm, tpm2.TPMSUClear)
+
+	clock3, err := tpm2.ReadClock{}.Execute(tpm)
+	if err != nil {
+		t.Fatalf("ReadClock() = %v", err)
+	}
+
+	// Restart should increment restartCount and leave resetCount alone.
+	if clock2.CurrentTime.ClockInfo.RestartCount != clock1.CurrentTime.ClockInfo.RestartCount+1 {
+		t.Errorf("restartCount after Restart was %v, want %v",
+			clock2.CurrentTime.ClockInfo.RestartCount,
+			clock1.CurrentTime.ClockInfo.RestartCount+1)
+	}
+	if clock2.CurrentTime.ClockInfo.ResetCount != clock1.CurrentTime.ClockInfo.ResetCount {
+		t.Errorf("resetCount after Restart was %v, want %v",
+			clock1.CurrentTime.ClockInfo.ResetCount,
+			clock1.CurrentTime.ClockInfo.ResetCount)
+	}
+
+	// Reset should reset restartCount to 0 and increment resetCount.
+	if clock3.CurrentTime.ClockInfo.RestartCount != 0 {
+		t.Errorf("restartCount after Reset was %v, want 0",
+			clock3.CurrentTime.ClockInfo.RestartCount)
+	}
+	if clock3.CurrentTime.ClockInfo.ResetCount != clock2.CurrentTime.ClockInfo.ResetCount+1 {
+		t.Errorf("resetCount after Reset was %v, want %v",
+			clock3.CurrentTime.ClockInfo.ResetCount,
+			clock2.CurrentTime.ClockInfo.ResetCount+1)
+	}
+}


### PR DESCRIPTION
This change implements the basic TCP TPM protocol, which is useful for connecting to a running TPM simulator. It also introduces some tests which are skipped if the --cmd_addr or --plat_addr flags aren't provided.

To aid in testing, this change also implements ReadClock.

A number of TCP commands aren't implemented and left for a future change.

Tested against a recent build of the TCG TPM simulator from https://github.com/trustedcomputinggroup/tpm