### PR TITLE
Check for padding bytes in EK cert

### DIFF
--- a/examples/tpm2-ekcert/main.go
+++ b/examples/tpm2-ekcert/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"crypto"
 	"crypto/x509"
+	"encoding/asn1"
 	"errors"
 	"flag"
 	"fmt"
@@ -79,8 +80,18 @@ func readEKCert(path string, certIdx, tmplIdx uint32) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading EK cert: %v", err)
 	}
+
+	// Identify if any `padding` exists in the EK cert that was read
+	var raw asn1.RawValue
+	paddingBytes, err := asn1.Unmarshal(ekCert, &raw)
+	if err != nil {
+		return nil, fmt.Errorf("ASN.1 Unmarshal failed: %v", err)
+	}
+	fmt.Printf("TPM NV Index bytes read: %d\n", len(ekCert))
+	fmt.Printf("Padding found from ASN.1 Unmarshal: %d\n", len(paddingBytes))
+
 	// Sanity-check that this is a valid certificate.
-	cert, err := x509.ParseCertificate(ekCert)
+	cert, err := x509.ParseCertificate(ekCert[0 : len(ekCert)-len(paddingBytes)])
 	if err != nil {
 		return nil, fmt.Errorf("parsing EK cert: %v", err)
 	}


### PR DESCRIPTION
Some TPM chips "pad" the EK cert that is stored in the TPM to completely fill up the NV index. Most TPM chips do NOT do this. If we try to parse the certificate with this extra padding, the x509.ParseCertificate function will return an "trailing bytes" error.

Before trying to parse the certificate, we need to identify how many bytes should be stripped from bytes that were read from the TPM. To do this, we can use the ASN.1 Unmarshal function to get the "padding" bytes. From there, we can use the length of the padding bytes and remove those bytes from the bytes we send to the x509.ParseCertificate function so it will parse correctly.