### PR TITLE
add test-vector-based unit test for KDFa and KDFe

### DIFF
--- a/tpm2/test/kdfa_test.go
+++ b/tpm2/test/kdfa_test.go
@@ -1,0 +1,24 @@
+package tpm2test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpm2/test/testvectors"
+)
+
+func TestKDFa(t *testing.T) {
+	for _, testcase := range testvectors.KDFa(t) {
+		h, err := tpm2.TPMIAlgHash(testcase.HashAlg).Hash()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		t.Run(testcase.Name, func(t *testing.T) {
+			result := tpm2.KDFa(h, testcase.Key, testcase.Label, testcase.ContextU, testcase.ContextV, testcase.Bits)
+			if !bytes.Equal(result, testcase.Result) {
+				t.Errorf("KDFa() = %x\nwant %x", result, testcase.Result)
+			}
+		})
+	}
+}

--- a/tpm2/test/kdfe_test.go
+++ b/tpm2/test/kdfe_test.go
@@ -1,0 +1,24 @@
+package tpm2test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpm2/test/testvectors"
+)
+
+func TestKDFe(t *testing.T) {
+	for _, testcase := range testvectors.KDFe(t) {
+		h, err := tpm2.TPMIAlgHash(testcase.HashAlg).Hash()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		t.Run(testcase.Name, func(t *testing.T) {
+			result := tpm2.KDFe(h, testcase.Z, testcase.Label, testcase.ContextU, testcase.ContextV, testcase.Bits)
+			if !bytes.Equal(result, testcase.Result) {
+				t.Errorf("KDFe() = %x\nwant %x", result, testcase.Result)
+			}
+		})
+	}
+}

--- a/tpm2/test/testvectors/testvectors.go
+++ b/tpm2/test/testvectors/testvectors.go
@@ -71,3 +71,55 @@ func RSALabeledEncapsulation(t *testing.T) []RSALabeledEncapsTestCase {
 
 	return testCases
 }
+
+//go:embed kdfa.json
+var kdfaJSON []byte
+
+// KDFaTestCase is a test case for KDFa.
+type KDFaTestCase struct {
+	Name     string
+	HashAlg  uint16
+	Key      hexBytes
+	Label    string
+	ContextU hexBytes
+	ContextV hexBytes
+	Bits     int
+	Result   hexBytes
+}
+
+func KDFa(t *testing.T) []KDFaTestCase {
+	t.Helper()
+
+	var testCases []KDFaTestCase
+	if err := json.Unmarshal(kdfaJSON, &testCases); err != nil {
+		t.Fatalf("could not unmarshal JSON: %v", err)
+	}
+
+	return testCases
+}
+
+//go:embed kdfe.json
+var kdfeJSON []byte
+
+// KDFeTestCase is a test case for KDFe.
+type KDFeTestCase struct {
+	Name     string
+	HashAlg  uint16
+	Z        hexBytes
+	Label    string
+	ContextU hexBytes
+	ContextV hexBytes
+	Bits     int
+	Result   hexBytes
+}
+
+func KDFe(t *testing.T) []KDFeTestCase {
+	t.Helper()
+
+	var testCases []KDFeTestCase
+	if err := json.Unmarshal(kdfeJSON, &testCases); err != nil {
+		t.Fatalf("could not unmarshal JSON: %v", err)
+	}
+
+	return testCases
+}


### PR DESCRIPTION
This PR uses the existing KDFe and KDFa test vectors to unit-test KDFa and KDFe. Unsurprisingly, these tests pass.