### PR TITLE
Allow policy session to be extended more programatically

### DIFF
--- a/tpm2/test/policy_test.go
+++ b/tpm2/test/policy_test.go
@@ -235,9 +235,8 @@ func TestPolicySignedUpdate(t *testing.T) {
 	}()
 
 	policySigned := PolicySigned{
-		AuthObject:    sk,
-		PolicySession: sess.Handle(),
-		PolicyRef:     TPM2BNonce{Buffer: []byte{5, 6, 7, 8}},
+		AuthObject: sk,
+		PolicyRef:  TPM2BNonce{Buffer: []byte{5, 6, 7, 8}},
 		Auth: TPMTSignature{
 			SigAlg: TPMAlgECDSA,
 			Signature: NewTPMUSignature(
@@ -249,7 +248,7 @@ func TestPolicySignedUpdate(t *testing.T) {
 		},
 	}
 
-	if _, err := policySigned.Execute(thetpm); err != nil {
+	if _, err := policySigned.ExecutePolicyInSession(thetpm, sess); err != nil {
 		t.Fatalf("executing PolicySigned: %v", err)
 	}
 

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -69,10 +69,13 @@ type Command[R any, PR *R] interface {
 }
 
 // PolicyCommand is a TPM command that can be part of a TPM policy.
-type PolicyCommand interface {
+type PolicyCommand[R any, PR *R] interface {
 	// Update updates the given policy hash according to the command
 	// parameters.
 	Update(policy *PolicyCalculator) error
+	// ExecutePolicyInSession executes the given policy command,
+	// using the given session as PolicySession.
+	ExecutePolicyInSession(t transport.TPM, s Session) (PR, error)
 }
 
 // Shutdown is the input to TPM2_Shutdown.
@@ -573,7 +576,7 @@ type ECDHZGenResponse struct {
 // Hash is the input to TPM2_Hash.
 // See definition in Part 3, Commands, section 15.4
 type Hash struct {
-	//data to be hashed
+	// data to be hashed
 	Data TPM2BMaxBuffer
 	// algorithm for the hash being computed - shall not be TPM_ALH_NULL
 	HashAlg TPMIAlgHash
@@ -1150,9 +1153,15 @@ func policyUpdate(policy *PolicyCalculator, cc TPMCC, arg2, arg3 []byte) error {
 	return policy.Update(arg3)
 }
 
-// Update implements the PolicyCommand interface.
+// Update updates the policy calculator with the policy command.
 func (cmd PolicySigned) Update(policy *PolicyCalculator) error {
 	return policyUpdate(policy, TPMCCPolicySigned, cmd.AuthObject.KnownName().Buffer, cmd.PolicyRef.Buffer)
+}
+
+// ExecutePolicyInSession extends the session with the policy command and returns the response.
+func (cmd PolicySigned) ExecutePolicyInSession(t transport.TPM, s Session) (*PolicySignedResponse, error) {
+	cmd.PolicySession = s.Handle()
+	return cmd.Execute(t)
 }
 
 // PolicySignedResponse is the response from TPM2_PolicySigned.
@@ -1193,9 +1202,15 @@ func (cmd PolicySecret) Execute(t transport.TPM, s ...Session) (*PolicySecretRes
 	return &rsp, nil
 }
 
-// Update implements the PolicyCommand interface.
+// Update updates the policy calculator with the policy command.
 func (cmd PolicySecret) Update(policy *PolicyCalculator) {
 	policyUpdate(policy, TPMCCPolicySecret, cmd.AuthHandle.KnownName().Buffer, cmd.PolicyRef.Buffer)
+}
+
+// ExecutePolicyInSession extends the session with the policy command and returns the response.
+func (cmd PolicySecret) ExecutePolicyInSession(t transport.TPM, s Session) (*PolicySecretResponse, error) {
+	cmd.PolicySession = s.Handle()
+	return cmd.Execute(t)
 }
 
 // PolicySecretResponse is the response from TPM2_PolicySecret.
@@ -1228,7 +1243,7 @@ func (cmd PolicyOr) Execute(t transport.TPM, s ...Session) (*PolicyOrResponse, e
 	return &rsp, nil
 }
 
-// Update implements the PolicyCommand interface.
+// Update updates the policy calculator with the policy command.
 func (cmd PolicyOr) Update(policy *PolicyCalculator) error {
 	policy.Reset()
 	var digests bytes.Buffer
@@ -1236,6 +1251,12 @@ func (cmd PolicyOr) Update(policy *PolicyCalculator) error {
 		digests.Write(digest.Buffer)
 	}
 	return policy.Update(TPMCCPolicyOR, digests.Bytes())
+}
+
+// ExecutePolicyInSession extends the session with the policy command and returns the response.
+func (cmd PolicyOr) ExecutePolicyInSession(t transport.TPM, s Session) (*PolicyOrResponse, error) {
+	cmd.PolicySession = s.Handle()
+	return cmd.Execute(t)
 }
 
 // PolicyOrResponse is the response from TPM2_PolicyOr.
@@ -1266,9 +1287,15 @@ func (cmd PolicyPCR) Execute(t transport.TPM, s ...Session) (*PolicyPCRResponse,
 	return &rsp, nil
 }
 
-// Update implements the PolicyCommand interface.
+// Update updates the policy calculator with the policy command.
 func (cmd PolicyPCR) Update(policy *PolicyCalculator) error {
 	return policy.Update(TPMCCPolicyPCR, cmd.Pcrs, cmd.PcrDigest.Buffer)
+}
+
+// ExecutePolicyInSession extends the session with the policy command and returns the response.
+func (cmd PolicyPCR) ExecutePolicyInSession(t transport.TPM, s Session) (*PolicyPCRResponse, error) {
+	cmd.PolicySession = s.Handle()
+	return cmd.Execute(t)
 }
 
 // PolicyPCRResponse is the response from TPM2_PolicyPCR.
@@ -1297,6 +1324,12 @@ func (cmd PolicyAuthValue) Execute(t transport.TPM, s ...Session) (*PolicyAuthVa
 // Update implements the PolicyAuthValue interface.
 func (cmd PolicyAuthValue) Update(policy *PolicyCalculator) error {
 	return policy.Update(TPMCCPolicyAuthValue)
+}
+
+// ExecutePolicyInSession extends the session with the policy command and returns the response.
+func (cmd PolicyAuthValue) ExecutePolicyInSession(t transport.TPM, s Session) (*PolicyAuthValueResponse, error) {
+	cmd.PolicySession = s.Handle()
+	return cmd.Execute(t)
 }
 
 // PolicyAuthValueResponse is the response from TPM2_PolicyAuthValue.
@@ -1333,6 +1366,13 @@ func (cmd PolicyDuplicationSelect) Update(policy *PolicyCalculator) error {
 	return policy.Update(TPMCCPolicyDuplicationSelect, cmd.NewParentName.Buffer, cmd.IncludeObject)
 }
 
+// ExecutePolicyInSession extends the session with the policy command and returns the response.
+func (cmd PolicyDuplicationSelect) ExecutePolicyInSession(t transport.TPM, s Session) (*PolicyDuplicationSelectResponse,
+	error) {
+	cmd.PolicySession = s.Handle()
+	return cmd.Execute(t)
+}
+
 // PolicyDuplicationSelectResponse is the response from TPM2_PolicyDuplicationSelect.
 type PolicyDuplicationSelectResponse struct{}
 
@@ -1366,7 +1406,7 @@ func (cmd PolicyNV) Execute(t transport.TPM, s ...Session) (*PolicyNVResponse, e
 	return &rsp, nil
 }
 
-// Update implements the PolicyCommand interface.
+// Update updates the policy calculator with the policy command.
 func (cmd PolicyNV) Update(policy *PolicyCalculator) error {
 	alg, err := policy.alg.Hash()
 	if err != nil {
@@ -1378,6 +1418,12 @@ func (cmd PolicyNV) Update(policy *PolicyCalculator) error {
 	binary.Write(h, binary.BigEndian, cmd.Operation)
 	args := h.Sum(nil)
 	return policy.Update(TPMCCPolicyNV, args, cmd.NVIndex.KnownName().Buffer)
+}
+
+// ExecutePolicyInSession extends the session with the policy command and returns the response.
+func (cmd PolicyNV) ExecutePolicyInSession(t transport.TPM, s Session) (*PolicyNVResponse, error) {
+	cmd.PolicySession = s.Handle()
+	return cmd.Execute(t)
 }
 
 // PolicyNVResponse is the response from TPM2_PolicyPCR.
@@ -1405,9 +1451,15 @@ func (cmd PolicyCommandCode) Execute(t transport.TPM, s ...Session) (*PolicyComm
 	return &rsp, nil
 }
 
-// Update implements the PolicyCommand interface.
+// Update updates the policy calculator with the policy command.
 func (cmd PolicyCommandCode) Update(policy *PolicyCalculator) error {
 	return policy.Update(TPMCCPolicyCommandCode, cmd.Code)
+}
+
+// ExecutePolicyInSession extends the session with the policy command and returns the response.
+func (cmd PolicyCommandCode) ExecutePolicyInSession(t transport.TPM, s Session) (*PolicyCommandCodeResponse, error) {
+	cmd.PolicySession = s.Handle()
+	return cmd.Execute(t)
 }
 
 // PolicyCommandCodeResponse is the response from TPM2_PolicyCommandCode.
@@ -1435,9 +1487,15 @@ func (cmd PolicyCPHash) Execute(t transport.TPM, s ...Session) (*PolicyCPHashRes
 	return &rsp, nil
 }
 
-// Update implements the PolicyCommand interface.
+// Update updates the policy calculator with the policy command.
 func (cmd PolicyCPHash) Update(policy *PolicyCalculator) error {
 	return policy.Update(TPMCCPolicyCpHash, cmd.CPHashA.Buffer)
+}
+
+// ExecutePolicyInSession extends the session with the policy command and returns the response.
+func (cmd PolicyCPHash) ExecutePolicyInSession(t transport.TPM, s Session) (*PolicyCPHashResponse, error) {
+	cmd.PolicySession = s.Handle()
+	return cmd.Execute(t)
 }
 
 // PolicyCPHashResponse is the response from TPM2_PolicyCpHash.
@@ -1471,9 +1529,15 @@ func (cmd PolicyAuthorize) Execute(t transport.TPM, s ...Session) (*PolicyAuthor
 	return &rsp, nil
 }
 
-// Update implements the PolicyCommand interface.
+// Update updates the policy calculator with the policy command.
 func (cmd PolicyAuthorize) Update(policy *PolicyCalculator) error {
 	return policyUpdate(policy, TPMCCPolicyAuthorize, cmd.KeySign.Buffer, cmd.PolicyRef.Buffer)
+}
+
+// ExecutePolicyInSession extends the session with the policy command and returns the response.
+func (cmd PolicyAuthorize) ExecutePolicyInSession(t transport.TPM, s Session) (*PolicyAuthorizeResponse, error) {
+	cmd.PolicySession = s.Handle()
+	return cmd.Execute(t)
 }
 
 // PolicyAuthorizeResponse is the response from TPM2_PolicyAuthorize.
@@ -1526,9 +1590,15 @@ func (cmd PolicyNVWritten) Execute(t transport.TPM, s ...Session) (*PolicyNVWrit
 	return &rsp, nil
 }
 
-// Update implements the PolicyCommand interface.
+// Update updates the policy calculator with the policy command.
 func (cmd PolicyNVWritten) Update(policy *PolicyCalculator) error {
 	return policy.Update(TPMCCPolicyNvWritten, cmd.WrittenSet)
+}
+
+// ExecutePolicyInSession extends the session with the policy command and returns the response.
+func (cmd PolicyNVWritten) ExecutePolicyInSession(t transport.TPM, s Session) (*PolicyNVWrittenResponse, error) {
+	cmd.PolicySession = s.Handle()
+	return cmd.Execute(t)
 }
 
 // PolicyNVWrittenResponse is the response from TPM2_PolicyNvWritten.
@@ -1559,10 +1629,16 @@ func (cmd PolicyAuthorizeNV) Execute(t transport.TPM, s ...Session) (*PolicyAuth
 	return &rsp, nil
 }
 
-// Update implements the PolicyCommand interface.
+// Update updates the policy calculator with the policy command.
 func (cmd PolicyAuthorizeNV) Update(policy *PolicyCalculator) error {
 	policy.Reset()
 	return policy.Update(TPMCCPolicyAuthorizeNV, cmd.NVIndex.KnownName().Buffer)
+}
+
+// ExecutePolicyInSession extends the session with the policy command and returns the response.
+func (cmd PolicyAuthorizeNV) ExecutePolicyInSession(t transport.TPM, s Session) (*PolicyAuthorizeNVResponse, error) {
+	cmd.PolicySession = s.Handle()
+	return cmd.Execute(t)
 }
 
 // PolicyAuthorizeNVResponse is the response from TPM2_PolicyAuthorizeNV.


### PR DESCRIPTION
This PR updates the PolicyCommand interface to add ExecutePolicyInSession. This new method extends the given policy session with the policy command and returns the response.