### PR TITLE
Support for TPM2_NV_NVReadLock for tpmdirect (tpm2)

### DIFF
--- a/tpm2/test/nv_test.go
+++ b/tpm2/test/nv_test.go
@@ -3,6 +3,7 @@ package tpm2test
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"testing"
 
 	. "github.com/google/go-tpm/tpm2"
@@ -205,5 +206,231 @@ func TestNVAuthIncrement(t *testing.T) {
 
 	if val2 != (val1 + 1) {
 		t.Errorf("want %v got %v", val1+1, val2)
+	}
+}
+
+func TestNVWriteLock(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	// Define the NV space with attributes that allow it to be locked
+	def := NVDefineSpace{
+		AuthHandle: TPMRHOwner,
+		PublicInfo: New2B(
+			TPMSNVPublic{
+				NVIndex: TPMHandle(0x0180000F),
+				NameAlg: TPMAlgSHA256,
+				Attributes: TPMANV{
+					OwnerWrite:   true,
+					OwnerRead:    true,
+					WriteSTClear: true, // Allow TPM2_NV_WriteLock to lock this index
+				},
+				DataSize: 4,
+			}),
+	}
+	if _, err := def.Execute(thetpm); err != nil {
+		t.Fatalf("Calling TPM2_NV_DefineSpace: %v", err)
+	}
+
+	pub, err := def.PublicInfo.Contents()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	nvName, err := NVName(pub)
+	if err != nil {
+		t.Fatalf("Calculating name of NV index: %v", err)
+	}
+
+	// Write data to the NV space
+	write := NVWrite{
+		AuthHandle: AuthHandle{
+			Handle: TPMRHOwner,
+			Auth:   PasswordAuth(nil),
+		},
+		NVIndex: NamedHandle{
+			Handle: pub.NVIndex,
+			Name:   *nvName,
+		},
+		Data: TPM2BMaxNVBuffer{
+			Buffer: []byte{0x01, 0x02, 0x03, 0x04},
+		},
+		Offset: 0,
+	}
+	if _, err := write.Execute(thetpm); err != nil {
+		t.Errorf("Calling TPM2_NV_Write: %v", err)
+	}
+
+	// Lock the NV space against further writes
+	lock := NVWriteLock{
+		AuthHandle: AuthHandle{
+			Handle: TPMRHOwner,
+			Auth:   PasswordAuth(nil),
+		},
+		NVIndex: NamedHandle{
+			Handle: pub.NVIndex,
+			Name:   *nvName,
+		},
+	}
+	if _, err := lock.Execute(thetpm); err != nil {
+		t.Errorf("Calling TPM2_NV_WriteLock: %v", err)
+	}
+
+	// Try to write to the NV space again, which should fail because it's locked
+	write2 := NVWrite{
+		AuthHandle: AuthHandle{
+			Handle: TPMRHOwner,
+			Auth:   PasswordAuth(nil),
+		},
+		NVIndex: NamedHandle{
+			Handle: pub.NVIndex,
+			Name:   *nvName,
+		},
+		Data: TPM2BMaxNVBuffer{
+			Buffer: []byte{0x05, 0x06, 0x07, 0x08},
+		},
+		Offset: 0,
+	}
+	_, err = write2.Execute(thetpm)
+	if !errors.Is(err, TPMRCNVLocked) {
+		t.Errorf("TPM2_NV_Write succeeded after NV_WriteLock, expected it to fail")
+	}
+
+	// Verify we can still read the data
+	read := NVRead{
+		AuthHandle: AuthHandle{
+			Handle: TPMRHOwner,
+			Auth:   PasswordAuth(nil),
+		},
+		NVIndex: NamedHandle{
+			Handle: pub.NVIndex,
+			Name:   *nvName,
+		},
+		Size:   4,
+		Offset: 0,
+	}
+	readRsp, err := read.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("Calling TPM2_NV_Read: %v", err)
+	}
+
+	// Verify the data is still the original data
+	expectedData := []byte{0x01, 0x02, 0x03, 0x04}
+	if !bytes.Equal(readRsp.Data.Buffer, expectedData) {
+		t.Errorf("Read data doesn't match expected data. Got %v, want %v", readRsp.Data.Buffer, expectedData)
+	}
+}
+
+func TestNVReadLock(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	// Define the NV space with attributes that allow it to be locked for reading
+	def := NVDefineSpace{
+		AuthHandle: TPMRHOwner,
+		PublicInfo: New2B(
+			TPMSNVPublic{
+				NVIndex: TPMHandle(0x0180000F),
+				NameAlg: TPMAlgSHA256,
+				Attributes: TPMANV{
+					OwnerWrite:  true,
+					OwnerRead:   true,
+					ReadSTClear: true, // Allow TPM2_NV_ReadLock to lock this index
+				},
+				DataSize: 4,
+			}),
+	}
+	if _, err := def.Execute(thetpm); err != nil {
+		t.Fatalf("Calling TPM2_NV_DefineSpace: %v", err)
+	}
+
+	pub, err := def.PublicInfo.Contents()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	nvName, err := NVName(pub)
+	if err != nil {
+		t.Fatalf("Calculating name of NV index: %v", err)
+	}
+
+	// Write data to the NV space
+	write := NVWrite{
+		AuthHandle: AuthHandle{
+			Handle: TPMRHOwner,
+			Auth:   PasswordAuth(nil),
+		},
+		NVIndex: NamedHandle{
+			Handle: pub.NVIndex,
+			Name:   *nvName,
+		},
+		Data: TPM2BMaxNVBuffer{
+			Buffer: []byte{0x01, 0x02, 0x03, 0x04},
+		},
+		Offset: 0,
+	}
+	if _, err := write.Execute(thetpm); err != nil {
+		t.Errorf("Calling TPM2_NV_Write: %v", err)
+	}
+
+	// Read the data to verify it's accessible
+	read := NVRead{
+		AuthHandle: AuthHandle{
+			Handle: TPMRHOwner,
+			Auth:   PasswordAuth(nil),
+		},
+		NVIndex: NamedHandle{
+			Handle: pub.NVIndex,
+			Name:   *nvName,
+		},
+		Size:   4,
+		Offset: 0,
+	}
+	readRsp, err := read.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("Calling TPM2_NV_Read before locking: %v", err)
+	}
+
+	// Verify the data is correct
+	expectedData := []byte{0x01, 0x02, 0x03, 0x04}
+	if !bytes.Equal(readRsp.Data.Buffer, expectedData) {
+		t.Errorf("Read data doesn't match expected data. Got %v, want %v", readRsp.Data.Buffer, expectedData)
+	}
+
+	// Lock the NV space against further reads
+	lock := NVReadLock{
+		AuthHandle: AuthHandle{
+			Handle: TPMRHOwner,
+			Auth:   PasswordAuth(nil),
+		},
+		NVIndex: NamedHandle{
+			Handle: pub.NVIndex,
+			Name:   *nvName,
+		},
+	}
+	if _, err := lock.Execute(thetpm); err != nil {
+		t.Errorf("Calling TPM2_NV_ReadLock: %v", err)
+	}
+
+	// Try to read from the NV space again, which should fail because it's locked
+	read2 := NVRead{
+		AuthHandle: AuthHandle{
+			Handle: TPMRHOwner,
+			Auth:   PasswordAuth(nil),
+		},
+		NVIndex: NamedHandle{
+			Handle: pub.NVIndex,
+			Name:   *nvName,
+		},
+		Size:   4,
+		Offset: 0,
+	}
+	_, err = read2.Execute(thetpm)
+	if !errors.Is(err, TPMRCNVLocked) {
+		t.Errorf("TPM2_NV_Read succeeded after NV_ReadLock, expected it to fail")
 	}
 }

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -2134,6 +2134,31 @@ type NVReadResponse struct {
 	Data TPM2BMaxNVBuffer
 }
 
+// NVReadLock is the input to TPM2_NV_NVReadLock.
+// See definition in Part 3, Commands, section 31.14.
+type NVReadLock struct {
+	// handle indicating the source of the authorization value
+	AuthHandle handle `gotpm:"handle,auth"`
+	// the NV index of the area to lock
+	NVIndex handle `gotpm:"handle"`
+}
+
+// Command implements the Command interface.
+func (NVReadLock) Command() TPMCC { return TPMCCNVReadLock }
+
+// Execute executes the command and returns the response.
+func (cmd NVReadLock) Execute(t transport.TPM, s ...Session) (*NVReadLockResponse, error) {
+	var rsp NVReadLockResponse
+	err := execute[NVReadLockResponse](t, cmd, &rsp, s...)
+	if err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+// NVReadLockResponse is the response from TPM2_NV_ReadLock.
+type NVReadLockResponse struct{}
+
 // NVCertify is the input to TPM2_NV_Certify.
 // See definition in Part 3, Commands, section 31.16.
 type NVCertify struct {


### PR DESCRIPTION
This commit adds support for the NVReadLock command and adds a test case for it. For completeness it also adds a test case for NVWriteLock.

I needed NVReadLock for a current project und found only NVWriteLock was implemented. The command is listed in google/go-tpm/issues#278 as a nice to have. I would like to upstream this.