### PR TITLE
Fix PolicySecret implementation of the PolicyCommand interface

### DIFF
--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -1194,8 +1194,8 @@ func (cmd PolicySecret) Execute(t transport.TPM, s ...Session) (*PolicySecretRes
 }
 
 // Update implements the PolicyCommand interface.
-func (cmd PolicySecret) Update(policy *PolicyCalculator) {
-	policyUpdate(policy, TPMCCPolicySecret, cmd.AuthHandle.KnownName().Buffer, cmd.PolicyRef.Buffer)
+func (cmd PolicySecret) Update(policy *PolicyCalculator) error {
+	return policyUpdate(policy, TPMCCPolicySecret, cmd.AuthHandle.KnownName().Buffer, cmd.PolicyRef.Buffer)
 }
 
 // PolicySecretResponse is the response from TPM2_PolicySecret.


### PR DESCRIPTION
`PolicySecret` now correctly implements the `PolicyCommand` interface, which requires to return an `error`