### PR TITLE
Add TPM2_GetTime Implementation

### DIFF
--- a/tpm2/test/get_time_test.go
+++ b/tpm2/test/get_time_test.go
@@ -1,0 +1,100 @@
+package tpm2test
+
+import (
+	"bytes"
+	"testing"
+
+	. "github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpm2/transport/simulator"
+)
+
+func TestGetTime(t *testing.T) {
+	thetpm, err := simulator.OpenSimulator()
+	if err != nil {
+		t.Fatalf("could not connect to TPM simulator: %v", err)
+	}
+	defer thetpm.Close()
+
+	createPrimary := CreatePrimary{
+		PrimaryHandle: TPMRHEndorsement,
+		InPublic: New2B(TPMTPublic{
+			Type:    TPMAlgRSA,
+			NameAlg: TPMAlgSHA256,
+			ObjectAttributes: TPMAObject{
+				SignEncrypt:         true,
+				FixedTPM:            true,
+				FixedParent:         true,
+				SensitiveDataOrigin: true,
+				UserWithAuth:        true,
+			},
+			Parameters: NewTPMUPublicParms(
+				TPMAlgRSA,
+				&TPMSRSAParms{
+					Scheme: TPMTRSAScheme{
+						Scheme: TPMAlgRSASSA,
+						Details: NewTPMUAsymScheme(
+							TPMAlgRSASSA,
+							&TPMSSigSchemeRSASSA{
+								HashAlg: TPMAlgSHA256,
+							},
+						),
+					},
+					KeyBits: 2048,
+				},
+			),
+		}),
+	}
+
+	rspCP, err := createPrimary.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("could not create key: %v", err)
+	}
+
+	flushContext := FlushContext{FlushHandle: rspCP.ObjectHandle}
+	defer flushContext.Execute(thetpm)
+
+	qualifyingData := []byte("migrationpains")
+
+	getTimeCommand := GetTime{
+		PrivacyAdminHandle: TPMRHEndorsement,
+		SignHandle:         NamedHandle{Handle: rspCP.ObjectHandle, Name: rspCP.Name},
+		QualifyingData:     TPM2BData{Buffer: qualifyingData},
+	}
+	getTimeResponse, err := getTimeCommand.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("GetTime failed: %v", err)
+	}
+
+	tpmsAttest, err := getTimeResponse.TimeInfo.Contents()
+
+	if err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	tpmsTimeAttestInfo, err := tpmsAttest.Attested.Time()
+
+	if err != nil {
+		t.Fatalf("union typed field did not have expected concrete type: %v", err)
+	}
+
+	if tpmsTimeAttestInfo.Time.ClockInfo.Clock != tpmsAttest.ClockInfo.Clock {
+		t.Errorf("clockInfo does not match in tpmsTimeAttestInfo (%x) vs tpmsAttest (%x)",
+			tpmsTimeAttestInfo.Time.ClockInfo.Clock, tpmsAttest.ClockInfo.Clock)
+	}
+
+	if tpmsTimeAttestInfo.Time.ClockInfo.ResetCount != tpmsAttest.ClockInfo.ResetCount {
+		t.Errorf("resetCount does not match in tpmsTimeAttestInfo (%x) vs tpmsAttest (%x)",
+			tpmsTimeAttestInfo.Time.ClockInfo.ResetCount, tpmsAttest.ClockInfo.ResetCount)
+	}
+
+	if tpmsTimeAttestInfo.Time.ClockInfo.RestartCount != tpmsAttest.ClockInfo.RestartCount {
+		t.Errorf("restartCount does not match in tpmsTimeAttestInfo (%x) vs tpmsAttest (%x)",
+			tpmsTimeAttestInfo.Time.ClockInfo.RestartCount, tpmsAttest.ClockInfo.RestartCount)
+	}
+
+	if !bytes.Equal(tpmsAttest.ExtraData.Buffer, qualifyingData) {
+		t.Errorf("extraData does not match. Saw (%v), expected (%v)",
+			tpmsAttest.ExtraData.Buffer,
+			qualifyingData)
+	}
+}

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -2197,3 +2197,36 @@ type NVCertifyResponse struct {
 	// the asymmetric signature over certifyInfo using the key referenced by signHandle
 	Signature TPMTSignature
 }
+
+// GetTime is the input to TPM2_GetTime.
+// See definition in Part 3, Commands, section 18.7.
+type GetTime struct {
+	// handle of the privacy administrator (Must be the value TPM_RH_ENDORSEMENT or command will fail)
+	PrivacyAdminHandle TPMIRHEndorsement `gotpm:"handle,auth"`
+	// the keyHandle identifier of a loaded key that can perform digital signatures
+	SignHandle handle `gotpm:"handle,auth"`
+	// data to "tick stamp"
+	QualifyingData TPM2BData
+	// signing scheme to use if the scheme for signHandle is TPM_ALG_NULL
+	InScheme TPMTSigScheme `gotpm:"nullable"`
+}
+
+// Command implements the Command interface.
+func (GetTime) Command() TPMCC { return TPMCCGetTime }
+
+// Execute executes the command and returns the response.
+func (cmd GetTime) Execute(t transport.TPM, s ...Session) (*GetTimeResponse, error) {
+	var rsp GetTimeResponse
+	if err := execute[GetTimeResponse](t, cmd, &rsp, s...); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+// GetTimeResponse is the response from TPM2_GetTime.
+type GetTimeResponse struct {
+	// standard TPM-generated attestation block
+	TimeInfo TPM2BAttest
+	// the signature over timeInfo
+	Signature TPMTSignature
+}


### PR DESCRIPTION
See section 18.7 of the [spec](https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-1.83-Part-3-Commands.pdf)

This is a useful command as it allows you to "tick stamp" arbitrary data, associating it with both with a signing key and a particular TPM clock state. Separately calling the TPM2_ReadClock/TPM2_Sign commands can not accomplish this.

The command code for TPM2_GetTime is enumerated in [constants.go](https://github.com/google/go-tpm/blob/6217e7f085d7021a2ff7a6a8feaea5c3063fd295/tpm2/constants.go#L152) but the actual command implementation does not exist, so this PR adds it.