### PR TITLE
fix(tpm2): honor `gotpm:"check"` tag in the unmarshaller

### DIFF
--- a/tpm2/check_tag_test.go
+++ b/tpm2/check_tag_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The Go-TPM Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+package tpm2
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// buildAttestBlob constructs a minimal TPMSAttest blob with an attacker-chosen
+// Magic value. The remaining fields are populated with zeros so that the blob
+// is otherwise unmarshallable (TPMSAttest is a fixed-shape struct apart from
+// its Attested union, for which we select TPM_ST_ATTEST_QUOTE and supply an
+// empty PCRSelect + empty PCRDigest).
+func buildAttestBlob(t *testing.T, magic uint32) []byte {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, magic)
+	binary.Write(buf, binary.BigEndian, uint16(0x8018)) // Type = TPM_ST_ATTEST_QUOTE
+	binary.Write(buf, binary.BigEndian, uint16(0))      // QualifiedSigner TPM2B_NAME size=0
+	binary.Write(buf, binary.BigEndian, uint16(0))      // ExtraData TPM2B_DATA size=0
+	buf.Write(make([]byte, 17))                         // ClockInfo (8+4+4+1)
+	binary.Write(buf, binary.BigEndian, uint64(0))      // FirmwareVersion
+	binary.Write(buf, binary.BigEndian, uint32(0))      // PCRSelect count=0
+	binary.Write(buf, binary.BigEndian, uint16(0))      // PCRDigest size=0
+	return buf.Bytes()
+}
+
+// TestUnmarshalAttest_RejectsWrongMagic asserts that the reflection-based
+// unmarshaller in this package honours the `gotpm:"check"` tag on
+// TPMSAttest.Magic and refuses to return a populated struct when the Magic
+// field does not equal TPM_GENERATED_VALUE.
+//
+// Prior to wiring the `check` tag into unmarshalStructField, the tag was
+// silently ignored. TPMSAttest.Magic is the only field carrying the tag, and
+// is exactly the boundary between "TPM-generated attestation" and "arbitrary
+// bytes signed by any key the verifier trusts". A verifier following the
+// pattern in tpm2/test/certify_test.go would have accepted forged quotes /
+// certifies whose Magic was zero (or any other attacker-chosen value), as
+// long as the surrounding signature verified — which it can, when the
+// signing key is a non-restricted signing key on the same TPM, a leaked
+// previously-trusted AK reused for ad-hoc Sign, or any cross-tenant signing
+// oracle.
+func TestUnmarshalAttest_RejectsWrongMagic(t *testing.T) {
+	cases := []struct {
+		name  string
+		magic uint32
+	}{
+		{"zero", 0x00000000},
+		{"deadbeef", 0xdeadbeef},
+		{"low-byte-collision", 0x47ff5443}, // byte-swapped TPM_GENERATED_VALUE
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blob := buildAttestBlob(t, tc.magic)
+			got, err := Unmarshal[TPMSAttest](blob)
+			if err == nil {
+				t.Fatalf("Unmarshal accepted Magic=0x%08x; this is the regression. Parsed Magic=0x%08x",
+					tc.magic, got.Magic)
+			}
+			if !strings.Contains(err.Error(), "TPM_GENERATED") {
+				t.Errorf("expected error to reference the TPM_GENERATED check; got: %v", err)
+			}
+		})
+	}
+}
+
+// TestUnmarshalAttest_AcceptsCorrectMagic asserts that the post-fix
+// unmarshaller does not regress the happy path: a blob whose Magic is
+// exactly TPM_GENERATED_VALUE (0xff544347) still unmarshalls.
+func TestUnmarshalAttest_AcceptsCorrectMagic(t *testing.T) {
+	blob := buildAttestBlob(t, uint32(TPMGeneratedValue))
+	got, err := Unmarshal[TPMSAttest](blob)
+	if err != nil {
+		t.Fatalf("Unmarshal rejected a correct Magic value: %v", err)
+	}
+	if got.Magic != TPMGeneratedValue {
+		t.Fatalf("Magic round-trip wrong: got 0x%08x want 0x%08x", got.Magic, TPMGeneratedValue)
+	}
+}

--- a/tpm2/reflect.go
+++ b/tpm2/reflect.go
@@ -611,6 +611,28 @@ func unmarshalStructField(buf *bytes.Buffer, v reflect.Value, i int) error {
 		}
 	}
 
+	// `gotpm:"check"` declares that the field's type implements `Check() error`
+	// and that the verifier must reject a blob whose field value fails that
+	// check. Without this, the only field currently carrying the tag
+	// (TPMSAttest.Magic, which must equal TPM_GENERATED_VALUE = 0xff544347)
+	// is silently accepted with any bytes, allowing arbitrary "signed
+	// attestation" blobs that the TPM itself would never have produced.
+	if hasTag(fieldType, "check") {
+		if checker, ok := fieldValue.Interface().(interface{ Check() error }); ok {
+			if err := checker.Check(); err != nil {
+				return fmt.Errorf("check tag failed for field '%v' of struct '%v': %w",
+					fieldType.Name, v.Type().Name(), err)
+			}
+		} else if fieldValue.CanAddr() {
+			if checker, ok := fieldValue.Addr().Interface().(interface{ Check() error }); ok {
+				if err := checker.Check(); err != nil {
+					return fmt.Errorf("check tag failed for field '%v' of struct '%v': %w",
+						fieldType.Name, v.Type().Name(), err)
+				}
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

`TPMSAttest.Magic` (tpm2/structures.go:1318) is declared with `gotpm:"check"`. The tag is meant to declare that the field's type implements `Check() error` and that the unmarshaller must reject a blob whose value fails the check. `TPMGenerated.Check()` (tpm2/structures.go:75-82) enforces `g == TPMGeneratedValue` (`0xff544347`).

`unmarshalStructField` in `tpm2/reflect.go` processes every other `gotpm:` tag (`skip`, `list`, `sized`, `sized8`, `tag`, `nullable`, `optional`, `handle`, `auth`, `bit`, `anon`) but never inspects `check`. Result: `TPMGenerated.Check()` has zero call sites anywhere in the package, the Magic field is the only field carrying the tag, and `Unmarshal[TPMSAttest]` happily returns a populated struct for any 4-byte Magic value.

A verifier following the pattern in `tpm2/test/certify_test.go` (lines 138-167) — call `.Contents()` to unmarshal the attest, marshal it back to compute the digest, verify the signature with the trusted AK, read `Attested.Quote().PCRDigest` and trust the result — therefore accepts forged "quotes" whose Magic is anything, as long as the surrounding signature verifies. The Magic field is precisely the boundary between "TPM-generated attestation" and "arbitrary bytes signed by any key the verifier trusts". Real-world signing oracles include non-restricted signing keys on the same TPM (TPM2_Sign with a non-restricted scheme does NOT prepend `TPM_GENERATED_VALUE`), vTPM-as-a-service back-ends, previously-leaked AKs reused for ad-hoc Sign, and cross-tenant signing endpoints.

Compare to the legacy package, which gets this right: `legacy/tpm2/structures.go:667-679` (`DecodeAttestationData`) explicitly rejects `ad.Magic != 0xff544347`.

## Fix

Wire the `check` tag into `unmarshalStructField`. After the field's bytes are read, if the field type implements `Check() error`, call it; return the error.

## Test plan

- [x] `go build ./tpm2/` clean.
- [x] New `tpm2/check_tag_test.go` adds a regression matrix for `Unmarshal[TPMSAttest]` that rejects `Magic=0x00000000`, `0xdeadbeef`, and the byte-swapped lookalike `0x47ff5443`, and that still accepts the legitimate `0xff544347`. The tests don't import the TPM simulator dep.
- Local PoC against `main` (commit `ab627a9`) before the fix: a hand-built 74-byte TPMSAttest with `Magic=0`, `Type=TPM_ST_ATTEST_QUOTE`, attacker-chosen 32-byte PCRDigest, attacker ECDSA signature over the blob verifies and the verifier reads `parsed.Attested.Quote().PCRDigest` as the attacker-chosen value. After this PR, `Unmarshal[TPMSAttest]` returns `check tag failed for field 'Magic' of struct 'TPMSAttest': TPM_GENERATED value should be 0xff544347, was 0x0` and the verifier short-circuits.