### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/legacy/tpm2/test/tpm2_test.go
+++ b/legacy/tpm2/test/tpm2_test.go
@@ -192,7 +192,7 @@ func TestGetCapability(t *testing.T) {
 		capa     Capability
 		count    uint32
 		property uint32
-		typ      interface{}
+		typ      any
 	}{
 		{CapabilityHandles, 1, uint32(HandleTypeTransient) << 24, tpmutil.Handle(0)},
 		{CapabilityAlgs, 1, 0, AlgorithmDescription{}},
@@ -524,7 +524,7 @@ func skipOnUnsupportedAlg(t testing.TB, rw io.ReadWriter, alg Algorithm) {
 	moreData := true
 	for i := uint32(0); moreData; i++ {
 		var err error
-		var descs []interface{}
+		var descs []any
 		descs, moreData, err = GetCapability(rw, CapabilityAlgs, 1, i)
 		if err != nil {
 			t.Fatalf("Could not get TPM algorithm capability: %v", err)

--- a/legacy/tpm2/tpm2.go
+++ b/legacy/tpm2/tpm2.go
@@ -219,7 +219,7 @@ func ReadClock(rw io.ReadWriter) (uint64, uint64, error) {
 	return decodeReadClock(resp)
 }
 
-func decodeGetCapability(in []byte) ([]interface{}, bool, error) {
+func decodeGetCapability(in []byte) ([]any, bool, error) {
 	var moreData byte
 	var capReported Capability
 
@@ -235,7 +235,7 @@ func decodeGetCapability(in []byte) ([]interface{}, bool, error) {
 			return nil, false, fmt.Errorf("could not unpack handle count: %v", err)
 		}
 
-		var handles []interface{}
+		var handles []any
 		for i := 0; i < int(numHandles); i++ {
 			var handle tpmutil.Handle
 			if err := tpmutil.UnpackBuf(buf, &handle); err != nil {
@@ -250,7 +250,7 @@ func decodeGetCapability(in []byte) ([]interface{}, bool, error) {
 			return nil, false, fmt.Errorf("could not unpack algorithm count: %v", err)
 		}
 
-		var algs []interface{}
+		var algs []any
 		for i := 0; i < int(numAlgs); i++ {
 			var alg AlgorithmDescription
 			if err := tpmutil.UnpackBuf(buf, &alg); err != nil {
@@ -265,7 +265,7 @@ func decodeGetCapability(in []byte) ([]interface{}, bool, error) {
 			return nil, false, fmt.Errorf("could not unpack fixed properties count: %v", err)
 		}
 
-		var props []interface{}
+		var props []any
 		for i := 0; i < int(numProps); i++ {
 			var prop TaggedProperty
 			if err := tpmutil.UnpackBuf(buf, &prop); err != nil {
@@ -276,7 +276,7 @@ func decodeGetCapability(in []byte) ([]interface{}, bool, error) {
 		return props, moreData > 0, nil
 
 	case CapabilityPCRs:
-		var pcrss []interface{}
+		var pcrss []any
 		pcrs, err := decodeTPMLPCRSelection(buf)
 		if err != nil {
 			return nil, false, fmt.Errorf("could not unpack pcr selection: %v", err)
@@ -301,7 +301,7 @@ func decodeGetCapability(in []byte) ([]interface{}, bool, error) {
 //
 // moreData is true if the TPM indicated that more data is available. Follow
 // the spec for the capability in question on how to query for more data.
-func GetCapability(rw io.ReadWriter, capa Capability, count, property uint32) (vals []interface{}, moreData bool, err error) {
+func GetCapability(rw io.ReadWriter, capa Capability, count, property uint32) (vals []any, moreData bool, err error) {
 	resp, err := runCommand(rw, TagNoSessions, CmdGetCapability, capa, property, count)
 	if err != nil {
 		return nil, false, err
@@ -1895,7 +1895,7 @@ func CertifyCreation(rw io.ReadWriter, objectAuth string, object, signer tpmutil
 	return decodeCertify(resp)
 }
 
-func runCommand(rw io.ReadWriter, tag tpmutil.Tag, Cmd tpmutil.Command, in ...interface{}) ([]byte, error) {
+func runCommand(rw io.ReadWriter, tag tpmutil.Tag, Cmd tpmutil.Command, in ...any) ([]byte, error) {
 	resp, code, err := tpmutil.RunCommand(rw, tag, Cmd, in...)
 	if err != nil {
 		return nil, err

--- a/tpm/commands.go
+++ b/tpm/commands.go
@@ -24,7 +24,7 @@ import (
 
 // submitTPMRequest sends a structure to the TPM device file and gets results
 // back, interpreting them as a new provided structure.
-func submitTPMRequest(rw io.ReadWriter, tag uint16, ord uint32, in []interface{}, out []interface{}) (uint32, error) {
+func submitTPMRequest(rw io.ReadWriter, tag uint16, ord uint32, in []any, out []any) (uint32, error) {
 	resp, code, err := tpmutil.RunCommand(rw, tpmutil.Tag(tag), tpmutil.Command(ord), in...)
 	if err != nil {
 		return 0, err
@@ -41,7 +41,7 @@ func submitTPMRequest(rw io.ReadWriter, tag uint16, ord uint32, in []interface{}
 // nonce.
 func oiap(rw io.ReadWriter) (*oiapResponse, error) {
 	var resp oiapResponse
-	out := []interface{}{&resp}
+	out := []any{&resp}
 	// In this case, we don't need to check ret, since all the information is
 	// contained in err.
 	if _, err := submitTPMRequest(rw, tagRQUCommand, ordOIAP, nil, out); err != nil {
@@ -54,9 +54,9 @@ func oiap(rw io.ReadWriter) (*oiapResponse, error) {
 // osap sends an OSAPCommand to the TPM and gets back authentication
 // information in an OSAPResponse.
 func osap(rw io.ReadWriter, osap *osapCommand) (*osapResponse, error) {
-	in := []interface{}{osap}
+	in := []any{osap}
 	var resp osapResponse
-	out := []interface{}{&resp}
+	out := []any{&resp}
 	// In this case, we don't need to check the ret value, since all the
 	// information is contained in err.
 	if _, err := submitTPMRequest(rw, tagRQUCommand, ordOSAP, in, out); err != nil {
@@ -75,11 +75,11 @@ func seal(rw io.ReadWriter, sc *sealCommand, pcrs *pcrInfoLong, data tpmutil.U32
 
 	// TODO(tmroeder): special-case pcrInfoLong in pack/unpack so we don't have
 	// to write out the length explicitly here.
-	in := []interface{}{sc, uint32(pcrsize), pcrs, data, ca}
+	in := []any{sc, uint32(pcrsize), pcrs, data, ca}
 
 	var tsd tpmStoredData
 	var ra responseAuth
-	out := []interface{}{&tsd, &ra}
+	out := []any{&tsd, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordSeal, in, out)
 	if err != nil {
 		return nil, nil, 0, err
@@ -90,11 +90,11 @@ func seal(rw io.ReadWriter, sc *sealCommand, pcrs *pcrInfoLong, data tpmutil.U32
 
 // unseal data sealed by the TPM.
 func unseal(rw io.ReadWriter, keyHandle tpmutil.Handle, sealed *tpmStoredData, ca1 *commandAuth, ca2 *commandAuth) ([]byte, *responseAuth, *responseAuth, uint32, error) {
-	in := []interface{}{keyHandle, sealed, ca1, ca2}
+	in := []any{keyHandle, sealed, ca1, ca2}
 	var outb tpmutil.U32Bytes
 	var ra1 responseAuth
 	var ra2 responseAuth
-	out := []interface{}{&outb, &ra1, &ra2}
+	out := []any{&outb, &ra1, &ra2}
 	ret, err := submitTPMRequest(rw, tagRQUAuth2Command, ordUnseal, in, out)
 	if err != nil {
 		return nil, nil, nil, 0, err
@@ -105,10 +105,10 @@ func unseal(rw io.ReadWriter, keyHandle tpmutil.Handle, sealed *tpmStoredData, c
 
 // authorizeMigrationKey authorizes a public key for migrations.
 func authorizeMigrationKey(rw io.ReadWriter, migrationScheme MigrationScheme, migrationKey pubKey, ca *commandAuth) ([]byte, *responseAuth, uint32, error) {
-	in := []interface{}{migrationScheme, migrationKey, ca}
+	in := []any{migrationScheme, migrationKey, ca}
 	var ra responseAuth
 	var migrationAuth migrationKeyAuth
-	out := []interface{}{&migrationAuth, &ra}
+	out := []any{&migrationAuth, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordAuthorizeMigrationKey, in, out)
 	if err != nil {
 		return nil, nil, 0, err
@@ -123,12 +123,12 @@ func authorizeMigrationKey(rw io.ReadWriter, migrationScheme MigrationScheme, mi
 
 // createMigrationBlob migrates a key from the TPM.
 func createMigrationBlob(rw io.ReadWriter, parentHandle tpmutil.Handle, migrationScheme MigrationScheme, migrationKey []byte, encData tpmutil.U32Bytes, ca1 *commandAuth, ca2 *commandAuth) ([]byte, []byte, *responseAuth, *responseAuth, uint32, error) {
-	in := []interface{}{parentHandle, migrationScheme, migrationKey, encData, ca1, ca2}
+	in := []any{parentHandle, migrationScheme, migrationKey, encData, ca1, ca2}
 	var rand tpmutil.U32Bytes
 	var outData tpmutil.U32Bytes
 	var ra1 responseAuth
 	var ra2 responseAuth
-	out := []interface{}{&rand, &outData, &ra1, &ra2}
+	out := []any{&rand, &outData, &ra1, &ra2}
 	ret, err := submitTPMRequest(rw, tagRQUAuth2Command, ordCreateMigrationBlob, in, out)
 	if err != nil {
 		return nil, nil, nil, nil, 0, err
@@ -142,7 +142,7 @@ func createMigrationBlob(rw io.ReadWriter, parentHandle tpmutil.Handle, migratio
 func flushSpecific(rw io.ReadWriter, handle tpmutil.Handle, resourceType uint32) error {
 	// In this case, all the information is in err, so we don't check the
 	// specific return-value details.
-	_, err := submitTPMRequest(rw, tagRQUCommand, ordFlushSpecific, []interface{}{handle, resourceType}, nil)
+	_, err := submitTPMRequest(rw, tagRQUCommand, ordFlushSpecific, []any{handle, resourceType}, nil)
 	return err
 }
 
@@ -151,10 +151,10 @@ func flushSpecific(rw io.ReadWriter, handle tpmutil.Handle, resourceType uint32)
 // TODO(tmroeder): support key12, too.
 func loadKey2(rw io.ReadWriter, k *key, ca *commandAuth) (tpmutil.Handle, *responseAuth, uint32, error) {
 	// We always load our keys with the SRK as the parent key.
-	in := []interface{}{khSRK, k, ca}
+	in := []any{khSRK, k, ca}
 	var keyHandle tpmutil.Handle
 	var ra responseAuth
-	out := []interface{}{&keyHandle, &ra}
+	out := []any{&keyHandle, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordLoadKey2, in, out)
 	if err != nil {
 		return 0, nil, 0, err
@@ -165,10 +165,10 @@ func loadKey2(rw io.ReadWriter, k *key, ca *commandAuth) (tpmutil.Handle, *respo
 
 // getPubKey gets a public key from the TPM
 func getPubKey(rw io.ReadWriter, keyHandle tpmutil.Handle, ca *commandAuth) (*pubKey, *responseAuth, uint32, error) {
-	in := []interface{}{keyHandle, ca}
+	in := []any{keyHandle, ca}
 	var pk pubKey
 	var ra responseAuth
-	out := []interface{}{&pk, &ra}
+	out := []any{&pk, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordGetPubKey, in, out)
 	if err != nil {
 		return nil, nil, 0, err
@@ -184,8 +184,8 @@ func getCapability(rw io.ReadWriter, cap, subcap uint32) ([]byte, error) {
 		return nil, err
 	}
 	var b tpmutil.U32Bytes
-	in := []interface{}{cap, tpmutil.U32Bytes(subCapBytes)}
-	out := []interface{}{&b}
+	in := []any{cap, tpmutil.U32Bytes(subCapBytes)}
+	out := []any{&b}
 	if _, err := submitTPMRequest(rw, tagRQUCommand, ordGetCapability, in, out); err != nil {
 		return nil, err
 	}
@@ -195,11 +195,11 @@ func getCapability(rw io.ReadWriter, cap, subcap uint32) ([]byte, error) {
 // nvDefineSpace allocates space in NVRAM
 func nvDefineSpace(rw io.ReadWriter, nvData NVDataPublic, enc Digest, ca *commandAuth) (*responseAuth, uint32, error) {
 	var ra responseAuth
-	in := []interface{}{nvData, enc}
+	in := []any{nvData, enc}
 	if ca != nil {
 		in = append(in, ca)
 	}
-	out := []interface{}{&ra}
+	out := []any{&ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordNVDefineSpace, in, out)
 	if err != nil {
 		return nil, 0, err
@@ -216,8 +216,8 @@ func nvReadValue(rw io.ReadWriter, index, offset, len uint32, ca *commandAuth) (
 	var ra responseAuth
 	var ret uint32
 	var err error
-	in := []interface{}{index, offset, len}
-	out := []interface{}{&b}
+	in := []any{index, offset, len}
+	out := []any{&b}
 	// Auth is needed
 	if ca != nil {
 		in = append(in, ca)
@@ -239,8 +239,8 @@ func nvReadValue(rw io.ReadWriter, index, offset, len uint32, ca *commandAuth) (
 func nvReadValueAuth(rw io.ReadWriter, index, offset, len uint32, ca *commandAuth) ([]byte, *responseAuth, uint32, error) {
 	var b tpmutil.U32Bytes
 	var ra responseAuth
-	in := []interface{}{index, offset, len, ca}
-	out := []interface{}{&b, &ra}
+	in := []any{index, offset, len, ca}
+	out := []any{&b, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordNVReadValueAuth, in, out)
 	if err != nil {
 		return nil, nil, 0, err
@@ -254,11 +254,11 @@ func nvReadValueAuth(rw io.ReadWriter, index, offset, len uint32, ca *commandAut
 func nvWriteValue(rw io.ReadWriter, index, offset, len uint32, data []byte, ca *commandAuth) ([]byte, *responseAuth, uint32, error) {
 	var b tpmutil.U32Bytes
 	var ra responseAuth
-	in := []interface{}{index, offset, len, data}
+	in := []any{index, offset, len, data}
 	if ca != nil {
 		in = append(in, ca)
 	}
-	out := []interface{}{&b, &ra}
+	out := []any{&b, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordNVWriteValue, in, out)
 	if err != nil {
 		return nil, nil, 0, err
@@ -272,8 +272,8 @@ func nvWriteValue(rw io.ReadWriter, index, offset, len uint32, data []byte, ca *
 func nvWriteValueAuth(rw io.ReadWriter, index, offset, len uint32, data []byte, ca *commandAuth) ([]byte, *responseAuth, uint32, error) {
 	var b tpmutil.U32Bytes
 	var ra responseAuth
-	in := []interface{}{index, offset, len, data, ca}
-	out := []interface{}{&b, &ra}
+	in := []any{index, offset, len, data, ca}
+	out := []any{&b, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordNVWriteValueAuth, in, out)
 	if err != nil {
 		return nil, nil, 0, err
@@ -287,13 +287,13 @@ func nvWriteValueAuth(rw io.ReadWriter, index, offset, len uint32, data []byte, 
 // TPM itself. Note that the input to quote2 must be exactly 20 bytes, so it is
 // normally the SHA1 hash of the data.
 func quote2(rw io.ReadWriter, keyHandle tpmutil.Handle, hash [20]byte, pcrs *pcrSelection, addVersion byte, ca *commandAuth) (*pcrInfoShort, *CapVersionInfo, []byte, []byte, *responseAuth, uint32, error) {
-	in := []interface{}{keyHandle, hash, pcrs, addVersion, ca}
+	in := []any{keyHandle, hash, pcrs, addVersion, ca}
 	var pcrShort pcrInfoShort
 	var capInfo CapVersionInfo
 	var capBytes tpmutil.U32Bytes
 	var sig tpmutil.U32Bytes
 	var ra responseAuth
-	out := []interface{}{&pcrShort, &capBytes, &sig, &ra}
+	out := []any{&pcrShort, &capBytes, &sig, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordQuote2, in, out)
 	if err != nil {
 		return nil, nil, nil, nil, nil, 0, err
@@ -315,11 +315,11 @@ func quote2(rw io.ReadWriter, keyHandle tpmutil.Handle, hash [20]byte, pcrs *pcr
 // quote performs a TPM 1.1 quote operation: it signs data using the
 // TPM_QUOTE_INFO structure for the current values of a selected set of PCRs.
 func quote(rw io.ReadWriter, keyHandle tpmutil.Handle, hash [20]byte, pcrs *pcrSelection, ca *commandAuth) (*pcrComposite, []byte, *responseAuth, uint32, error) {
-	in := []interface{}{keyHandle, hash, pcrs, ca}
+	in := []any{keyHandle, hash, pcrs, ca}
 	var pcrc pcrComposite
 	var sig tpmutil.U32Bytes
 	var ra responseAuth
-	out := []interface{}{&pcrc, &sig, &ra}
+	out := []any{&pcrc, &sig, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordQuote, in, out)
 	if err != nil {
 		return nil, nil, nil, 0, err
@@ -331,12 +331,12 @@ func quote(rw io.ReadWriter, keyHandle tpmutil.Handle, hash [20]byte, pcrs *pcrS
 // makeIdentity requests that the TPM create a new AIK. It returns the handle to
 // this new key.
 func makeIdentity(rw io.ReadWriter, encAuth Digest, idDigest Digest, k *key, ca1 *commandAuth, ca2 *commandAuth) (*key, []byte, *responseAuth, *responseAuth, uint32, error) {
-	in := []interface{}{encAuth, idDigest, k, ca1, ca2}
+	in := []any{encAuth, idDigest, k, ca1, ca2}
 	var aik key
 	var sig tpmutil.U32Bytes
 	var ra1 responseAuth
 	var ra2 responseAuth
-	out := []interface{}{&aik, &sig, &ra1, &ra2}
+	out := []any{&aik, &sig, &ra1, &ra2}
 	ret, err := submitTPMRequest(rw, tagRQUAuth2Command, ordMakeIdentity, in, out)
 	if err != nil {
 		return nil, nil, nil, nil, 0, err
@@ -348,11 +348,11 @@ func makeIdentity(rw io.ReadWriter, encAuth Digest, idDigest Digest, k *key, ca1
 // activateIdentity provides the TPM with an EK encrypted challenge and asks it to
 // decrypt the challenge and return the secret (symmetric key).
 func activateIdentity(rw io.ReadWriter, keyHandle tpmutil.Handle, blob tpmutil.U32Bytes, ca1 *commandAuth, ca2 *commandAuth) (*symKey, *responseAuth, *responseAuth, uint32, error) {
-	in := []interface{}{keyHandle, blob, ca1, ca2}
+	in := []any{keyHandle, blob, ca1, ca2}
 	var symkey symKey
 	var ra1 responseAuth
 	var ra2 responseAuth
-	out := []interface{}{&symkey, &ra1, &ra2}
+	out := []any{&symkey, &ra1, &ra2}
 	ret, err := submitTPMRequest(rw, tagRQUAuth2Command, ordActivateIdentity, in, out)
 	if err != nil {
 		return nil, nil, nil, 0, err
@@ -364,9 +364,9 @@ func activateIdentity(rw io.ReadWriter, keyHandle tpmutil.Handle, blob tpmutil.U
 // resetLockValue resets the dictionary-attack lock in the TPM, using owner
 // auth.
 func resetLockValue(rw io.ReadWriter, ca *commandAuth) (*responseAuth, uint32, error) {
-	in := []interface{}{ca}
+	in := []any{ca}
 	var ra responseAuth
-	out := []interface{}{&ra}
+	out := []any{&ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordResetLockValue, in, out)
 	if err != nil {
 		return nil, 0, err
@@ -378,10 +378,10 @@ func resetLockValue(rw io.ReadWriter, ca *commandAuth) (*responseAuth, uint32, e
 // ownerReadInternalPub uses owner auth and OSAP to read either the endorsement
 // key (using khEK) or the SRK (using khSRK).
 func ownerReadInternalPub(rw io.ReadWriter, kh tpmutil.Handle, ca *commandAuth) (*pubKey, *responseAuth, uint32, error) {
-	in := []interface{}{kh, ca}
+	in := []any{kh, ca}
 	var pk pubKey
 	var ra responseAuth
-	out := []interface{}{&pk, &ra}
+	out := []any{&pk, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordOwnerReadInternalPub, in, out)
 	if err != nil {
 		return nil, nil, 0, err
@@ -395,10 +395,10 @@ func ownerReadInternalPub(rw io.ReadWriter, kh tpmutil.Handle, ca *commandAuth) 
 // owner is established, the endorsement key can be retrieved using
 // ownerReadInternalPub.
 func readPubEK(rw io.ReadWriter, n Nonce) (*pubKey, Digest, uint32, error) {
-	in := []interface{}{n}
+	in := []any{n}
 	var pk pubKey
 	var d Digest
-	out := []interface{}{&pk, &d}
+	out := []any{&pk, &d}
 	ret, err := submitTPMRequest(rw, tagRQUCommand, ordReadPubEK, in, out)
 	if err != nil {
 		return nil, d, 0, err
@@ -410,9 +410,9 @@ func readPubEK(rw io.ReadWriter, n Nonce) (*pubKey, Digest, uint32, error) {
 // ownerClear uses owner auth to clear the TPM. After this operation, a caller
 // can take ownership of the TPM with TPM_TakeOwnership.
 func ownerClear(rw io.ReadWriter, ca *commandAuth) (*responseAuth, uint32, error) {
-	in := []interface{}{ca}
+	in := []any{ca}
 	var ra responseAuth
-	out := []interface{}{&ra}
+	out := []any{&ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordOwnerClear, in, out)
 	if err != nil {
 		return nil, 0, err
@@ -426,10 +426,10 @@ func ownerClear(rw io.ReadWriter, ca *commandAuth) (*responseAuth, uint32, error
 // TPM can be put into this state using TPM_OwnerClear. The encOwnerAuth and
 // encSRKAuth values must be encrypted using the endorsement key.
 func takeOwnership(rw io.ReadWriter, encOwnerAuth tpmutil.U32Bytes, encSRKAuth tpmutil.U32Bytes, srk *key, ca *commandAuth) (*key, *responseAuth, uint32, error) {
-	in := []interface{}{pidOwner, encOwnerAuth, encSRKAuth, srk, ca}
+	in := []any{pidOwner, encOwnerAuth, encSRKAuth, srk, ca}
 	var k key
 	var ra responseAuth
-	out := []interface{}{&k, &ra}
+	out := []any{&k, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordTakeOwnership, in, out)
 	if err != nil {
 		return nil, nil, 0, err
@@ -440,10 +440,10 @@ func takeOwnership(rw io.ReadWriter, encOwnerAuth tpmutil.U32Bytes, encSRKAuth t
 
 // Creates a wrapped key under the SRK.
 func createWrapKey(rw io.ReadWriter, encUsageAuth Digest, encMigrationAuth Digest, keyInfo *key, ca *commandAuth) (*key, *responseAuth, uint32, error) {
-	in := []interface{}{khSRK, encUsageAuth, encMigrationAuth, keyInfo, ca}
+	in := []any{khSRK, encUsageAuth, encMigrationAuth, keyInfo, ca}
 	var k key
 	var ra responseAuth
-	out := []interface{}{&k, &ra}
+	out := []any{&k, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordCreateWrapKey, in, out)
 	if err != nil {
 		return nil, nil, 0, err
@@ -453,10 +453,10 @@ func createWrapKey(rw io.ReadWriter, encUsageAuth Digest, encMigrationAuth Diges
 }
 
 func sign(rw io.ReadWriter, keyHandle tpmutil.Handle, data tpmutil.U32Bytes, ca *commandAuth) ([]byte, *responseAuth, uint32, error) {
-	in := []interface{}{keyHandle, data, ca}
+	in := []any{keyHandle, data, ca}
 	var signature tpmutil.U32Bytes
 	var ra responseAuth
-	out := []interface{}{&signature, &ra}
+	out := []any{&signature, &ra}
 	ret, err := submitTPMRequest(rw, tagRQUAuth1Command, ordSign, in, out)
 	if err != nil {
 		return nil, nil, 0, err
@@ -466,7 +466,7 @@ func sign(rw io.ReadWriter, keyHandle tpmutil.Handle, data tpmutil.U32Bytes, ca 
 }
 
 func pcrReset(rw io.ReadWriter, pcrs *pcrSelection) error {
-	_, err := submitTPMRequest(rw, tagRQUCommand, ordPcrReset, []interface{}{pcrs}, nil)
+	_, err := submitTPMRequest(rw, tagRQUCommand, ordPcrReset, []any{pcrs}, nil)
 	if err != nil {
 		return err
 	}

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -47,9 +47,9 @@ func GetKeys(rw io.ReadWriter) ([]tpmutil.Handle, error) {
 
 // PcrExtend extends a value into the right PCR by index.
 func PcrExtend(rw io.ReadWriter, pcrIndex uint32, pcr pcrValue) ([]byte, error) {
-	in := []interface{}{pcrIndex, pcr}
+	in := []any{pcrIndex, pcr}
 	var d pcrValue
-	out := []interface{}{&d}
+	out := []any{&d}
 	if _, err := submitTPMRequest(rw, tagRQUCommand, ordExtend, in, out); err != nil {
 		return nil, err
 	}
@@ -59,9 +59,9 @@ func PcrExtend(rw io.ReadWriter, pcrIndex uint32, pcr pcrValue) ([]byte, error) 
 
 // ReadPCR reads a PCR value from the TPM.
 func ReadPCR(rw io.ReadWriter, pcrIndex uint32) ([]byte, error) {
-	in := []interface{}{pcrIndex}
+	in := []any{pcrIndex}
 	var v pcrValue
-	out := []interface{}{&v}
+	out := []any{&v}
 	// There's no need to check the ret value here, since the err value contains
 	// all the necessary information.
 	if _, err := submitTPMRequest(rw, tagRQUCommand, ordPCRRead, in, out); err != nil {
@@ -89,8 +89,8 @@ func FetchPCRValues(rw io.ReadWriter, pcrVals []int) ([]byte, error) {
 // GetRandom gets random bytes from the TPM.
 func GetRandom(rw io.ReadWriter, size uint32) ([]byte, error) {
 	var b tpmutil.U32Bytes
-	in := []interface{}{size}
-	out := []interface{}{&b}
+	in := []any{size}
+	out := []any{&b}
 	// There's no need to check the ret value here, since the err value
 	// contains all the necessary information.
 	if _, err := submitTPMRequest(rw, tagRQUCommand, ordGetRandom, in, out); err != nil {
@@ -120,7 +120,7 @@ func LoadKey2(rw io.ReadWriter, keyBlob []byte, srkAuth []byte) (tpmutil.Handle,
 	defer osapr.Close(rw)
 	defer zeroBytes(sharedSecret[:])
 
-	authIn := []interface{}{ordLoadKey2, k}
+	authIn := []any{ordLoadKey2, k}
 	ca, err := newCommandAuth(osapr.AuthHandle, osapr.NonceEven, nil, sharedSecret[:], authIn)
 	if err != nil {
 		return 0, err
@@ -132,7 +132,7 @@ func LoadKey2(rw io.ReadWriter, keyBlob []byte, srkAuth []byte) (tpmutil.Handle,
 	}
 
 	// Check the response authentication.
-	raIn := []interface{}{ret, ordLoadKey2}
+	raIn := []any{ret, ordLoadKey2}
 	if err := ra.verify(ca.NonceOdd, sharedSecret[:], raIn); err != nil {
 		return 0, err
 	}
@@ -159,7 +159,7 @@ func Quote2(rw io.ReadWriter, handle tpmutil.Handle, data []byte, pcrVals []int,
 	if err != nil {
 		return nil, err
 	}
-	authIn := []interface{}{ordQuote2, hash, pcrSel, addVersion}
+	authIn := []any{ordQuote2, hash, pcrSel, addVersion}
 	ca, err := newCommandAuth(osapr.AuthHandle, osapr.NonceEven, nil, sharedSecret[:], authIn)
 	if err != nil {
 		return nil, err
@@ -172,7 +172,7 @@ func Quote2(rw io.ReadWriter, handle tpmutil.Handle, data []byte, pcrVals []int,
 	}
 
 	// Check response authentication.
-	raIn := []interface{}{ret, ordQuote2, pcrShort, tpmutil.U32Bytes(capBytes), tpmutil.U32Bytes(sig)}
+	raIn := []any{ret, ordQuote2, pcrShort, tpmutil.U32Bytes(capBytes), tpmutil.U32Bytes(sig)}
 	if err := ra.verify(ca.NonceOdd, sharedSecret[:], raIn); err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func GetPubKey(rw io.ReadWriter, keyHandle tpmutil.Handle, srkAuth []byte) ([]by
 	defer osapr.Close(rw)
 	defer zeroBytes(sharedSecret[:])
 
-	authIn := []interface{}{ordGetPubKey}
+	authIn := []any{ordGetPubKey}
 	ca, err := newCommandAuth(osapr.AuthHandle, osapr.NonceEven, nil, sharedSecret[:], authIn)
 	if err != nil {
 		return nil, err
@@ -204,7 +204,7 @@ func GetPubKey(rw io.ReadWriter, keyHandle tpmutil.Handle, srkAuth []byte) ([]by
 	}
 
 	// Check response authentication for TPM_GetPubKey.
-	raIn := []interface{}{ret, ordGetPubKey, pk}
+	raIn := []any{ret, ordGetPubKey, pk}
 	if err := ra.verify(ca.NonceOdd, sharedSecret[:], raIn); err != nil {
 		return nil, err
 	}
@@ -258,7 +258,7 @@ func newOSAPSession(rw io.ReadWriter, entityType uint16, entityValue tpmutil.Han
 // newCommandAuth creates a new commandAuth structure over the given
 // parameters, using the given secret and the given odd nonce, if provided,
 // for the HMAC. If no odd nonce is provided, one is randomly generated.
-func newCommandAuth(authHandle tpmutil.Handle, nonceEven Nonce, nonceOdd *Nonce, key []byte, params []interface{}) (*commandAuth, error) {
+func newCommandAuth(authHandle tpmutil.Handle, nonceEven Nonce, nonceOdd *Nonce, key []byte, params []any) (*commandAuth, error) {
 	// Auth = HMAC-SHA1(key, SHA1(params) || NonceEven || NonceOdd || ContSession)
 	digestBytes, err := tpmutil.Pack(params...)
 	if err != nil {
@@ -296,7 +296,7 @@ func newCommandAuth(authHandle tpmutil.Handle, nonceEven Nonce, nonceOdd *Nonce,
 // verify checks that the response authentication was correct.
 // It computes the SHA1 of params, and computes the HMAC-SHA1 of this digest
 // with the authentication parameters of ra along with the given odd nonce.
-func (ra *responseAuth) verify(nonceOdd Nonce, key []byte, params []interface{}) error {
+func (ra *responseAuth) verify(nonceOdd Nonce, key []byte, params []any) error {
 	// Auth = HMAC-SHA1(key, SHA1(params) || ra.NonceEven || NonceOdd || ra.ContSession)
 	digestBytes, err := tpmutil.Pack(params...)
 	if err != nil {
@@ -359,7 +359,7 @@ func sealHelper(rw io.ReadWriter, pcrInfo *pcrInfoLong, data []byte, srkAuth []b
 	// digest = SHA1(ordSeal || encAuth || binary.Size(pcrInfo) || pcrInfo ||
 	//               len(data) || data)
 	//
-	authIn := []interface{}{ordSeal, sc.EncAuth, uint32(binary.Size(pcrInfo)), pcrInfo, tpmutil.U32Bytes(data)}
+	authIn := []any{ordSeal, sc.EncAuth, uint32(binary.Size(pcrInfo)), pcrInfo, tpmutil.U32Bytes(data)}
 	ca, err := newCommandAuth(osapr.AuthHandle, osapr.NonceEven, nil, sharedSecret[:], authIn)
 	if err != nil {
 		return nil, err
@@ -371,7 +371,7 @@ func sealHelper(rw io.ReadWriter, pcrInfo *pcrInfoLong, data []byte, srkAuth []b
 	}
 
 	// Check the response authentication.
-	raIn := []interface{}{ret, ordSeal, sealed}
+	raIn := []any{ret, ordSeal, sealed}
 	if err := ra.verify(ca.NonceOdd, sharedSecret[:], raIn); err != nil {
 		return nil, err
 	}
@@ -431,7 +431,7 @@ func Unseal(rw io.ReadWriter, sealed []byte, srkAuth []byte) ([]byte, error) {
 
 	// The digest for auth1 and auth2 for the unseal command is computed as
 	// digest = SHA1(ordUnseal || tsd)
-	authIn := []interface{}{ordUnseal, tsd}
+	authIn := []any{ordUnseal, tsd}
 
 	// The first commandAuth uses the shared secret as an HMAC key.
 	ca1, err := newCommandAuth(osapr.AuthHandle, osapr.NonceEven, nil, sharedSecret[:], authIn)
@@ -452,7 +452,7 @@ func Unseal(rw io.ReadWriter, sealed []byte, srkAuth []byte) ([]byte, error) {
 	}
 
 	// Check the response authentication.
-	raIn := []interface{}{ret, ordUnseal, tpmutil.U32Bytes(unsealed)}
+	raIn := []any{ret, ordUnseal, tpmutil.U32Bytes(unsealed)}
 	if err := ra1.verify(ca1.NonceOdd, sharedSecret[:], raIn); err != nil {
 		return nil, err
 	}
@@ -482,7 +482,7 @@ func Quote(rw io.ReadWriter, handle tpmutil.Handle, data []byte, pcrNums []int, 
 	if err != nil {
 		return nil, nil, err
 	}
-	authIn := []interface{}{ordQuote, hash, pcrSel}
+	authIn := []any{ordQuote, hash, pcrSel}
 	ca, err := newCommandAuth(osapr.AuthHandle, osapr.NonceEven, nil, sharedSecret[:], authIn)
 	if err != nil {
 		return nil, nil, err
@@ -494,7 +494,7 @@ func Quote(rw io.ReadWriter, handle tpmutil.Handle, data []byte, pcrNums []int, 
 	}
 
 	// Check response authentication.
-	raIn := []interface{}{ret, ordQuote, pcrc, tpmutil.U32Bytes(sig)}
+	raIn := []any{ret, ordQuote, pcrc, tpmutil.U32Bytes(sig)}
 	if err := ra.verify(ca.NonceOdd, sharedSecret[:], raIn); err != nil {
 		return nil, nil, err
 	}
@@ -596,7 +596,7 @@ func MakeIdentity(rw io.ReadWriter, srkAuth []byte, ownerAuth []byte, aikAuth []
 	//
 	// digest = SHA1(ordMakeIdentity || encAuth || caDigest || aik)
 	//
-	authIn := []interface{}{ordMakeIdentity, encAuth, caDigest, aik}
+	authIn := []any{ordMakeIdentity, encAuth, caDigest, aik}
 	ca1, err := newCommandAuth(osaprSRK.AuthHandle, osaprSRK.NonceEven, nil, sharedSecretSRK[:], authIn)
 	if err != nil {
 		return nil, err
@@ -613,7 +613,7 @@ func MakeIdentity(rw io.ReadWriter, srkAuth []byte, ownerAuth []byte, aikAuth []
 	}
 
 	// Check response authentication.
-	raIn := []interface{}{ret, ordMakeIdentity, k, tpmutil.U32Bytes(sig)}
+	raIn := []any{ret, ordMakeIdentity, k, tpmutil.U32Bytes(sig)}
 	if err := ra1.verify(ca1.NonceOdd, sharedSecretSRK[:], raIn); err != nil {
 		return nil, err
 	}
@@ -685,7 +685,7 @@ func ActivateIdentity(rw io.ReadWriter, aikAuth []byte, ownerAuth []byte, aik tp
 	defer osaprOwn.Close(rw)
 	defer zeroBytes(sharedSecretOwn[:])
 
-	authIn := []interface{}{ordActivateIdentity, tpmutil.U32Bytes(asym)}
+	authIn := []any{ordActivateIdentity, tpmutil.U32Bytes(asym)}
 	ca1, err := newCommandAuth(oiaprAIK.AuthHandle, oiaprAIK.NonceEven, nil, aikAuth, authIn)
 	if err != nil {
 		return nil, fmt.Errorf("newCommandAuth failed: %v", err)
@@ -701,7 +701,7 @@ func ActivateIdentity(rw io.ReadWriter, aikAuth []byte, ownerAuth []byte, aik tp
 	}
 
 	// Check response authentication.
-	raIn := []interface{}{ret, ordActivateIdentity, symkey}
+	raIn := []any{ret, ordActivateIdentity, symkey}
 	if err := ra1.verify(ca1.NonceOdd, aikAuth, raIn); err != nil {
 		return nil, fmt.Errorf("aik resAuth failed to verify: %v", err)
 	}
@@ -770,7 +770,7 @@ func ResetLockValue(rw io.ReadWriter, ownerAuth Digest) error {
 	//
 	// digest = SHA1(ordResetLockValue)
 	//
-	authIn := []interface{}{ordResetLockValue}
+	authIn := []any{ordResetLockValue}
 	ca, err := newCommandAuth(osaprOwn.AuthHandle, osaprOwn.NonceEven, nil, sharedSecretOwn[:], authIn)
 	if err != nil {
 		return err
@@ -782,7 +782,7 @@ func ResetLockValue(rw io.ReadWriter, ownerAuth Digest) error {
 	}
 
 	// Check response authentication.
-	raIn := []interface{}{ret, ordResetLockValue}
+	raIn := []any{ret, ordResetLockValue}
 	if err := ra.verify(ca.NonceOdd, sharedSecretOwn[:], raIn); err != nil {
 		return err
 	}
@@ -807,7 +807,7 @@ func ownerReadInternalHelper(rw io.ReadWriter, kh tpmutil.Handle, ownerAuth Dige
 	//
 	// digest = SHA1(ordOwnerReadInternalPub || kh)
 	//
-	authIn := []interface{}{ordOwnerReadInternalPub, kh}
+	authIn := []any{ordOwnerReadInternalPub, kh}
 	ca, err := newCommandAuth(osaprOwn.AuthHandle, osaprOwn.NonceEven, nil, sharedSecretOwn[:], authIn)
 	if err != nil {
 		return nil, err
@@ -819,7 +819,7 @@ func ownerReadInternalHelper(rw io.ReadWriter, kh tpmutil.Handle, ownerAuth Dige
 	}
 
 	// Check response authentication.
-	raIn := []interface{}{ret, ordOwnerReadInternalPub, pk}
+	raIn := []any{ret, ordOwnerReadInternalPub, pk}
 	if err := ra.verify(ca.NonceOdd, sharedSecretOwn[:], raIn); err != nil {
 		return nil, err
 	}
@@ -942,7 +942,7 @@ func NVDefineSpace(rw io.ReadWriter, nvData NVDataPublic, ownAuth []byte) error 
 
 		encAuthData := sha1.Sum(xorData)
 
-		authIn := []interface{}{ordNVDefineSpace, nvData, encAuthData}
+		authIn := []any{ordNVDefineSpace, nvData, encAuthData}
 		ca, err := newCommandAuth(osaprOwn.AuthHandle, osaprOwn.NonceEven, nil, sharedSecretOwn[:], authIn)
 		if err != nil {
 			return err
@@ -951,7 +951,7 @@ func NVDefineSpace(rw io.ReadWriter, nvData NVDataPublic, ownAuth []byte) error 
 		if err != nil {
 			return fmt.Errorf("failed to define space in NVRAM: %v", err)
 		}
-		raIn := []interface{}{ret, ordNVDefineSpace}
+		raIn := []any{ret, ordNVDefineSpace}
 		if err := ra.verify(ca.NonceOdd, sharedSecretOwn[:], raIn); err != nil {
 			return fmt.Errorf("failed to verify authenticity of response: %v", err)
 		}
@@ -978,7 +978,7 @@ func NVReadValue(rw io.ReadWriter, index, offset, len uint32, ownAuth []byte) ([
 	}
 	defer osaprOwn.Close(rw)
 	defer zeroBytes(sharedSecretOwn[:])
-	authIn := []interface{}{ordNVReadValue, index, offset, len}
+	authIn := []any{ordNVReadValue, index, offset, len}
 	ca, err := newCommandAuth(osaprOwn.AuthHandle, osaprOwn.NonceEven, nil, sharedSecretOwn[:], authIn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct owner auth fields: %v", err)
@@ -987,7 +987,7 @@ func NVReadValue(rw io.ReadWriter, index, offset, len uint32, ownAuth []byte) ([
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from NVRAM: %v", err)
 	}
-	raIn := []interface{}{ret, ordNVReadValue, tpmutil.U32Bytes(data)}
+	raIn := []any{ret, ordNVReadValue, tpmutil.U32Bytes(data)}
 	if err := ra.verify(ca.NonceOdd, sharedSecretOwn[:], raIn); err != nil {
 		return nil, fmt.Errorf("failed to verify authenticity of response: %v", err)
 	}
@@ -1009,7 +1009,7 @@ func NVReadValueAuth(rw io.ReadWriter, index, offset, len uint32, auth []byte) (
 	}
 	defer osapr.Close(rw)
 	defer zeroBytes(sharedSecret[:])
-	authIn := []interface{}{ordNVReadValueAuth, index, offset, len}
+	authIn := []any{ordNVReadValueAuth, index, offset, len}
 	ca, err := newCommandAuth(osapr.AuthHandle, osapr.NonceEven, nil, sharedSecret[:], authIn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct auth fields: %v", err)
@@ -1018,7 +1018,7 @@ func NVReadValueAuth(rw io.ReadWriter, index, offset, len uint32, auth []byte) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from NVRAM: %v", err)
 	}
-	raIn := []interface{}{ret, ordNVReadValueAuth, tpmutil.U32Bytes(data)}
+	raIn := []any{ret, ordNVReadValueAuth, tpmutil.U32Bytes(data)}
 	if err := ra.verify(ca.NonceOdd, sharedSecret[:], raIn); err != nil {
 		return nil, fmt.Errorf("failed to verify authenticity of response: %v", err)
 	}
@@ -1041,7 +1041,7 @@ func NVWriteValue(rw io.ReadWriter, index, offset uint32, data []byte, ownAuth [
 	}
 	defer osaprOwn.Close(rw)
 	defer zeroBytes(sharedSecretOwn[:])
-	authIn := []interface{}{ordNVWriteValue, index, offset, len(data), data}
+	authIn := []any{ordNVWriteValue, index, offset, len(data), data}
 	ca, err := newCommandAuth(osaprOwn.AuthHandle, osaprOwn.NonceEven, nil, sharedSecretOwn[:], authIn)
 	if err != nil {
 		return fmt.Errorf("failed to construct owner auth fields: %v", err)
@@ -1050,7 +1050,7 @@ func NVWriteValue(rw io.ReadWriter, index, offset uint32, data []byte, ownAuth [
 	if err != nil {
 		return fmt.Errorf("failed to write to NVRAM: %v", err)
 	}
-	raIn := []interface{}{ret, ordNVWriteValue, tpmutil.U32Bytes(data)}
+	raIn := []any{ret, ordNVWriteValue, tpmutil.U32Bytes(data)}
 	if err := ra.verify(ca.NonceOdd, sharedSecretOwn[:], raIn); err != nil {
 		return fmt.Errorf("failed to verify authenticity of response: %v", err)
 	}
@@ -1072,7 +1072,7 @@ func NVWriteValueAuth(rw io.ReadWriter, index, offset uint32, data []byte, auth 
 	}
 	defer osapr.Close(rw)
 	defer zeroBytes(sharedSecret[:])
-	authIn := []interface{}{ordNVWriteValueAuth, index, offset, len(data), data}
+	authIn := []any{ordNVWriteValueAuth, index, offset, len(data), data}
 	ca, err := newCommandAuth(osapr.AuthHandle, osapr.NonceEven, nil, sharedSecret[:], authIn)
 	if err != nil {
 		return fmt.Errorf("failed to construct auth fields: %v", err)
@@ -1081,7 +1081,7 @@ func NVWriteValueAuth(rw io.ReadWriter, index, offset uint32, data []byte, auth 
 	if err != nil {
 		return fmt.Errorf("failed to write to NVRAM: %v", err)
 	}
-	raIn := []interface{}{ret, ordNVWriteValueAuth, tpmutil.U32Bytes(data)}
+	raIn := []any{ret, ordNVWriteValueAuth, tpmutil.U32Bytes(data)}
 	if err := ra.verify(ca.NonceOdd, sharedSecret[:], raIn); err != nil {
 		return fmt.Errorf("failed to verify authenticity of response: %v", err)
 	}
@@ -1226,7 +1226,7 @@ func OwnerClear(rw io.ReadWriter, ownerAuth Digest) error {
 	//
 	// digest = SHA1(ordOwnerClear)
 	//
-	authIn := []interface{}{ordOwnerClear}
+	authIn := []any{ordOwnerClear}
 	ca, err := newCommandAuth(osaprOwn.AuthHandle, osaprOwn.NonceEven, nil, sharedSecretOwn[:], authIn)
 	if err != nil {
 		return err
@@ -1238,7 +1238,7 @@ func OwnerClear(rw io.ReadWriter, ownerAuth Digest) error {
 	}
 
 	// Check response authentication.
-	raIn := []interface{}{ret, ordOwnerClear}
+	raIn := []any{ret, ordOwnerClear}
 	if err := ra.verify(ca.NonceOdd, sharedSecretOwn[:], raIn); err != nil {
 		return err
 	}
@@ -1306,7 +1306,7 @@ func TakeOwnership(rw io.ReadWriter, newOwnerAuth Digest, newSRKAuth Digest, pub
 	// The digest for TakeOwnership is
 	//
 	// SHA1(ordTakeOwnership || pidOwner || encOwnerAuth || encSRKAuth || srk)
-	authIn := []interface{}{ordTakeOwnership, pidOwner, tpmutil.U32Bytes(encOwnerAuth), tpmutil.U32Bytes(encSRKAuth), srk}
+	authIn := []any{ordTakeOwnership, pidOwner, tpmutil.U32Bytes(encOwnerAuth), tpmutil.U32Bytes(encSRKAuth), srk}
 	ca, err := newCommandAuth(oiapr.AuthHandle, oiapr.NonceEven, nil, newOwnerAuth[:], authIn)
 	if err != nil {
 		return err
@@ -1317,7 +1317,7 @@ func TakeOwnership(rw io.ReadWriter, newOwnerAuth Digest, newSRKAuth Digest, pub
 		return err
 	}
 
-	raIn := []interface{}{ret, ordTakeOwnership, k}
+	raIn := []any{ret, ordTakeOwnership, k}
 	return ra.verify(ca.NonceOdd, newOwnerAuth[:], raIn)
 }
 
@@ -1402,7 +1402,7 @@ func createWrapKeyHelper(rw io.ReadWriter, srkAuth []byte, keyFlags KeyFlags, us
 		PCRInfo: pcrInfoBytes,
 	}
 
-	authIn := []interface{}{ordCreateWrapKey, encUsageAuth, encMigrationAuth, keyInfo}
+	authIn := []any{ordCreateWrapKey, encUsageAuth, encMigrationAuth, keyInfo}
 	ca, err := newCommandAuth(osapr.AuthHandle, osapr.NonceEven, &nonceOdd, sharedSecret[:], authIn)
 	if err != nil {
 		return nil, err
@@ -1413,7 +1413,7 @@ func createWrapKeyHelper(rw io.ReadWriter, srkAuth []byte, keyFlags KeyFlags, us
 		return nil, err
 	}
 
-	raIn := []interface{}{ret, ordCreateWrapKey, k}
+	raIn := []any{ret, ordCreateWrapKey, k}
 	if err = ra.verify(ca.NonceOdd, sharedSecret[:], raIn); err != nil {
 		return nil, err
 	}
@@ -1493,7 +1493,7 @@ func AuthorizeMigrationKey(rw io.ReadWriter, ownerAuth Digest, migrationKey cryp
 
 	// The digest for auth for the authorizeMigrationKey command is computed as
 	// SHA1(ordAuthorizeMigrationkey || migrationScheme || migrationKey)
-	authIn := []interface{}{ordAuthorizeMigrationKey, scheme, pub}
+	authIn := []any{ordAuthorizeMigrationKey, scheme, pub}
 
 	// The commandAuth uses the shared secret as an HMAC key.
 	ca, err := newCommandAuth(osapr.AuthHandle, osapr.NonceEven, nil, sharedSecret[:], authIn)
@@ -1533,7 +1533,7 @@ func CreateMigrationBlob(rw io.ReadWriter, srkAuth Digest, migrationAuth Digest,
 
 	// The digest for auth1 and auth2 for the createMigrationBlob command is
 	// SHA1(ordCreateMigrationBlob || migrationScheme || migrationKeyBlob || encData)
-	authIn := []interface{}{ordCreateMigrationBlob, msRewrap, migrationKeyBlob, encData}
+	authIn := []any{ordCreateMigrationBlob, msRewrap, migrationKeyBlob, encData}
 
 	// The first commandAuth uses the shared secret as an HMAC key.
 	ca1, err := newCommandAuth(osapr.AuthHandle, osapr.NonceEven, nil, sharedSecret[:], authIn)
@@ -1588,7 +1588,7 @@ func Sign(rw io.ReadWriter, keyAuth []byte, keyHandle tpmutil.Handle, hash crypt
 	defer osapr.Close(rw)
 	defer zeroBytes(sharedSecret[:])
 
-	authIn := []interface{}{ordSign, tpmutil.U32Bytes(data)}
+	authIn := []any{ordSign, tpmutil.U32Bytes(data)}
 	ca, err := newCommandAuth(osapr.AuthHandle, osapr.NonceEven, nil, sharedSecret[:], authIn)
 	if err != nil {
 		return nil, err
@@ -1599,7 +1599,7 @@ func Sign(rw io.ReadWriter, keyAuth []byte, keyHandle tpmutil.Handle, hash crypt
 		return nil, err
 	}
 
-	raIn := []interface{}{ret, ordSign, tpmutil.U32Bytes(signature)}
+	raIn := []any{ret, ordSign, tpmutil.U32Bytes(signature)}
 	err = ra.verify(ca.NonceOdd, sharedSecret[:], raIn)
 	if err != nil {
 		return nil, err
@@ -1625,8 +1625,8 @@ func PcrReset(rw io.ReadWriter, pcrs []int) error {
 // vendors got it wrong and didn't call TPM_DisableForceClear.
 // It removes forcefully the ownership of the TPM.
 func ForceClear(rw io.ReadWriter) error {
-	in := []interface{}{}
-	out := []interface{}{}
+	in := []any{}
+	out := []any{}
 	_, err := submitTPMRequest(rw, tagRQUCommand, ordForceClear, in, out)
 
 	return err
@@ -1635,8 +1635,8 @@ func ForceClear(rw io.ReadWriter) error {
 // Startup performs TPM_Startup(TPM_ST_CLEAR) to initialize the TPM.
 func startup(rw io.ReadWriter) error {
 	var typ uint16 = 0x0001 // TPM_ST_CLEAR
-	in := []interface{}{typ}
-	out := []interface{}{}
+	in := []any{typ}
+	out := []any{}
 	_, err := submitTPMRequest(rw, tagRQUCommand, ordStartup, in, out)
 
 	return err
@@ -1654,8 +1654,8 @@ func createEK(rw io.ReadWriter) error {
 		0x00, 0x00, 0x00, 0x02, // NumPrimes = 2
 		0x00, 0x00, 0x00, 0x00, // ExponentSize = 0 (default 65537 exponent)
 	}
-	in := []interface{}{antiReplay, keyInfo}
-	out := []interface{}{}
+	in := []any{antiReplay, keyInfo}
+	out := []any{}
 	_, err := submitTPMRequest(rw, tagRQUCommand, ordCreateEndorsementKeyPair, in, out)
 
 	return err

--- a/tpm2/errors.go
+++ b/tpm2/errors.go
@@ -547,7 +547,7 @@ func (r TPMRC) Is(target error) bool {
 // As returns whether the error can be assigned to the given interface type.
 // If supported, it updates the value pointed at by target.
 // Supports the Fmt1Error type.
-func (r TPMRC) As(target interface{}) bool {
+func (r TPMRC) As(target any) bool {
 	pFmt1, ok := target.(*TPMFmt1Error)
 	if !ok {
 		return false

--- a/tpm2/names.go
+++ b/tpm2/names.go
@@ -18,7 +18,7 @@ func HandleName(h TPMHandle) TPM2BName {
 
 // objectOrNVName calculates the Name of an NV index or object.
 // pub is a pointer to either a TPMTPublic or TPMSNVPublic.
-func objectOrNVName(alg TPMAlgID, pub interface{}) (*TPM2BName, error) {
+func objectOrNVName(alg TPMAlgID, pub any) (*TPM2BName, error) {
 	h, err := alg.Hash()
 	if err != nil {
 		return nil, err

--- a/tpm2/policy.go
+++ b/tpm2/policy.go
@@ -35,7 +35,7 @@ func (p *PolicyCalculator) Reset() {
 // Update updates the internal state of the policy hash by appending the
 // current state with the given contents, and updating the new state to the
 // hash of that.
-func (p *PolicyCalculator) Update(data ...interface{}) error {
+func (p *PolicyCalculator) Update(data ...any) error {
 	hash := p.hash.New()
 	hash.Write(p.state)
 	var buf bytes.Buffer

--- a/tpm2/transport/googleipmi/ec_common.go
+++ b/tpm2/transport/googleipmi/ec_common.go
@@ -42,7 +42,7 @@ func getECChecksum(data ...[]byte) byte {
 
 // ecSendCommand delivers EC command and extra params(if any) to Titan using the
 // given command dispatcher.
-func ecSendCommand(ctx context.Context, cd commandDispatcher, cmd ecCommand, args ...interface{}) ([]byte, error) {
+func ecSendCommand(ctx context.Context, cd commandDispatcher, cmd ecCommand, args ...any) ([]byte, error) {
 	ecCmd, err := formatEcCommand(cmd, args...)
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ type ecHostResponseHeader struct {
 // formatEcCommand formats a Titan host command with given parameters as a raw
 // EC command byte array. All parameters must be either sized integral primitive
 // types (e.g., uint16, int32), or structs containing valid parameters.
-func formatEcCommand(cmd ecCommand, args ...interface{}) ([]byte, error) {
+func formatEcCommand(cmd ecCommand, args ...any) ([]byte, error) {
 	var argBuf bytes.Buffer
 	for _, arg := range args {
 		if err := binary.Write(&argBuf, binary.LittleEndian, arg); err != nil {

--- a/tpmutil/encoding.go
+++ b/tpmutil/encoding.go
@@ -32,7 +32,7 @@ var (
 // fixed length or slices of fixed-length types and packs them into a single
 // byte array using binary.Write. It updates the CommandHeader to have the right
 // length.
-func packWithHeader(ch commandHeader, cmd ...interface{}) ([]byte, error) {
+func packWithHeader(ch commandHeader, cmd ...any) ([]byte, error) {
 	hdrSize := binary.Size(ch)
 	body, err := Pack(cmd...)
 	if err != nil {
@@ -54,7 +54,7 @@ func packWithHeader(ch commandHeader, cmd ...interface{}) ([]byte, error) {
 // It has one difference from encoding/binary: it encodes byte slices with a
 // prepended length, to match how the TPM encodes variable-length arrays. If
 // you wish to add a byte slice without length prefix, use RawBytes.
-func Pack(elts ...interface{}) ([]byte, error) {
+func Pack(elts ...any) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	if err := packType(buf, elts...); err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ func packValue(buf io.Writer, v reflect.Value) error {
 	return nil
 }
 
-func packType(buf io.Writer, elts ...interface{}) error {
+func packType(buf io.Writer, elts ...any) error {
 	for _, e := range elts {
 		if err := packValue(buf, reflect.ValueOf(e)); err != nil {
 			return err
@@ -150,7 +150,7 @@ func tryUnmarshal(buf io.Reader, v reflect.Value) (bool, error) {
 
 // Unpack is a convenience wrapper around UnpackBuf. Unpack returns the number
 // of bytes read from b to fill elts and error, if any.
-func Unpack(b []byte, elts ...interface{}) (int, error) {
+func Unpack(b []byte, elts ...any) (int, error) {
 	buf := bytes.NewBuffer(b)
 	err := UnpackBuf(buf, elts...)
 	read := len(b) - buf.Len()
@@ -193,7 +193,7 @@ func unpackValue(buf io.Reader, v reflect.Value) error {
 // slice by first reading an integer with lengthPrefixSize bytes, then reading
 // that many bytes. It assumes that incoming values are pointers to values so
 // that, e.g., underlying slices can be resized as needed.
-func UnpackBuf(buf io.Reader, elts ...interface{}) error {
+func UnpackBuf(buf io.Reader, elts ...any) error {
 	for _, e := range elts {
 		v := reflect.ValueOf(e)
 		if v.Kind() != reflect.Ptr {

--- a/tpmutil/encoding_test.go
+++ b/tpmutil/encoding_test.go
@@ -67,7 +67,7 @@ type nestedSlice struct {
 
 func TestEncodingPackType(t *testing.T) {
 	buf := make([]byte, 10)
-	inputs := []interface{}{
+	inputs := []any{
 		uint32(3),
 		buf,
 		&buf,
@@ -90,7 +90,7 @@ func TestEncodingPackTypeWriteFail(t *testing.T) {
 
 	tests := []struct {
 		limit int
-		in    interface{}
+		in    any
 	}{
 		{4, &u32WithOneByte},
 		{3, &u32Empty},
@@ -207,7 +207,7 @@ func TestSelfMarshaler(t *testing.T) {
 	var empty32 U32Bytes
 	subTests := []struct {
 		encoded []byte
-		decoded interface{}
+		decoded any
 	}{
 		{[]byte{0, 0}, &empty16},
 		{[]byte{0, 1, 137}, &empty16},

--- a/tpmutil/run.go
+++ b/tpmutil/run.go
@@ -89,7 +89,7 @@ func RunCommandRaw(rw io.ReadWriter, inb []byte) ([]byte, error) {
 // body (without response header) and response code from the header. Returned
 // error may be nil if response code is not RCSuccess; caller should check
 // both.
-func RunCommand(rw io.ReadWriter, tag Tag, cmd Command, in ...interface{}) ([]byte, ResponseCode, error) {
+func RunCommand(rw io.ReadWriter, tag Tag, cmd Command, in ...any) ([]byte, ResponseCode, error) {
 	inb, err := packWithHeader(commandHeader{tag, 0, cmd}, in...)
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
Replace `interface{}` with `any` (available since Go 1.18) across the codebase.

This change is purely mechanical and does not alter behavior.