### PR TITLE
commands: implement TPM2_StirRandom

### DIFF
--- a/tpm2/test/stir_random_test.go
+++ b/tpm2/test/stir_random_test.go
@@ -1,0 +1,73 @@
+package tpm2test
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpm2/transport/testhelper"
+)
+
+func TestStirRandom(t *testing.T) {
+	thetpm := testhelper.Open(t)
+	defer thetpm.Close()
+
+	src := StirRandom{
+		InData: TPM2BSensitiveData{
+			Buffer: []byte("wombat"),
+		},
+	}
+
+	if _, err := src.Execute(thetpm); err != nil {
+		t.Fatalf("StirRandom failed: %v", err)
+	}
+
+	// The TPM must still be able to produce random data afterwards.
+	grc := GetRandom{
+		BytesRequested: 16,
+	}
+
+	rsp, err := grc.Execute(thetpm)
+	if err != nil {
+		t.Fatalf("GetRandom failed: %v", err)
+	}
+	if len(rsp.RandomBytes.Buffer) != 16 {
+		t.Errorf("GetRandom returned %v bytes, want 16", len(rsp.RandomBytes.Buffer))
+	}
+}
+
+// TestStirRandomSize pins the bound on inData. It comes from TPM2B_SENSITIVE_DATA
+// holding at most MAX_SYM_DATA (128) octets, not from TPM2_StirRandom itself.
+func TestStirRandomSize(t *testing.T) {
+	thetpm := testhelper.Open(t)
+	defer thetpm.Close()
+
+	for _, tc := range []struct {
+		name string
+		size int
+		want error
+	}{
+		{"Empty", 0, nil},
+		{"MaxSymData", 128, nil},
+		{"TooBig", 129, TPMRCSize},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := StirRandom{
+				InData: TPM2BSensitiveData{
+					Buffer: make([]byte, tc.size),
+				},
+			}
+
+			_, err := src.Execute(thetpm)
+			if tc.want == nil {
+				if err != nil {
+					t.Errorf("StirRandom with %v octets failed: %v", tc.size, err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.want) {
+				t.Errorf("StirRandom with %v octets = %v, want %v", tc.size, err, tc.want)
+			}
+		})
+	}
+}

--- a/tpm2/tpm2.go
+++ b/tpm2/tpm2.go
@@ -682,6 +682,30 @@ type GetRandomResponse struct {
 	RandomBytes TPM2BDigest
 }
 
+// StirRandom is the input to TPM2_StirRandom.
+// See definition in Part 3, Commands, section 16.2
+type StirRandom struct {
+	// additional input, as defined in SP 800-90A
+	// TPM2B_SENSITIVE_DATA holds at most MAX_SYM_DATA (128) octets; the TPM
+	// responds with TPM_RC_SIZE if InData is larger.
+	InData TPM2BSensitiveData
+}
+
+// Command implements the Command interface.
+func (StirRandom) Command() TPMCC { return TPMCCStirRandom }
+
+// Execute executes the command and returns the response.
+func (cmd StirRandom) Execute(t transport.TPM, s ...Session) (*StirRandomResponse, error) {
+	var rsp StirRandomResponse
+	if err := execute[StirRandomResponse](t, cmd, &rsp, s...); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+// StirRandomResponse is the response from TPM2_StirRandom.
+type StirRandomResponse struct{}
+
 // HashSequenceStart is the input to TPM2_HashSequenceStart.
 // See definition in Part 3, Commands, section 17.3
 type HashSequenceStart struct {


### PR DESCRIPTION
Closes #440. This implements TPM2_StirRandom in`tpm2` (Part 3, Commands, section 16.2).

Includes a test to assert the following from the spec: _"The inData parameter may not be larger than 128 octets."_